### PR TITLE
Fix dispatch hanging when load() is called twice with the same key

### DIFF
--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -575,6 +575,23 @@ public class DataLoaderTest {
         assertThat(loadCalls, equalTo(asList(asList("A", "B"),
                 asList("A", "C"), asList("A", "B", "C"))));
     }
+    @Test
+    public void should_work_with_duplicate_keys() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader =
+                idLoader(newOptions().setCachingEnabled(false), loadCalls);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+        CompletableFuture<String> future3 = identityLoader.load("A");
+        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone() && future3.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(future3.get(), equalTo("A"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B", "A"))));
+    }
 
     // It is resilient to job queue ordering
 


### PR DESCRIPTION
Fixes #14 