### PR TITLE
POC on DataLoader automatic dispatch capability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ repositories {
     }
 }
 
+def slf4jVersion = '1.7.25'
 def releaseVersion = System.properties.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
 group = 'org.dataloader'
@@ -55,6 +56,8 @@ task myJavadocs(type: Javadoc) {
 }
 
 dependencies {
+    compile 'org.slf4j:slf4j-api:' + slf4jVersion
+    testCompile 'org.slf4j:slf4j-simple:' + slf4jVersion
     testCompile "junit:junit:$junitVersion"
     testCompile 'org.awaitility:awaitility:2.0.0'
 }

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -57,7 +57,7 @@ import static org.dataloader.impl.Assertions.nonNull;
 public class DataLoader<K, V> {
 
     private final DataLoaderHelper<K, V> helper;
-    private final DataLoaderOptions loaderOptions;
+    protected final DataLoaderOptions loaderOptions;
     private final CacheMap<Object, CompletableFuture<V>> futureCache;
     private final StatisticsCollector stats;
 

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -88,7 +88,7 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
         if (loaderOptions.batchingEnabled()) {
             LOGGER.trace("requesting dispatch for batched loader");
             resultCreator.accept(this);
-            dispatcher.addToBatch(this);
+            dispatcher.scheduleBatch(this);
         }
         
         return load;

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -1,0 +1,139 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.dataloader.nextgen;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import static java.util.Collections.emptyList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import java.util.function.Consumer;
+import org.dataloader.BatchLoader;
+import org.dataloader.DataLoader;
+
+/**
+ *
+ * @author gkesler
+ */
+public class AutoDataLoader<K, V> extends DataLoader<K, V> implements AutoCloseable {
+    private final Dispatcher dispatcher;
+    private final Deque<CompletableFuture<List<V>>> results = new ArrayDeque<>();
+    private volatile Consumer<AutoDataLoader<K, V>> addResult;
+    
+    public AutoDataLoader(BatchLoader<K, V> batchLoadFunction) {
+        this(batchLoadFunction, new Dispatcher());
+    }
+
+    public AutoDataLoader(BatchLoader<K, V> batchLoadFunction, Dispatcher dispatcher) {
+        this(batchLoadFunction, null, dispatcher);
+    }
+    
+    public AutoDataLoader(BatchLoader<K, V> batchLoadFunction, AutoDataLoaderOptions options) {
+        this(batchLoadFunction, options, options.getDispatcher());
+    }
+    
+    public AutoDataLoader(BatchLoader<K, V> batchLoadFunction, AutoDataLoaderOptions options, Dispatcher dispatcher) {
+        super(batchLoadFunction, options);
+
+        newResult();
+        
+        Objects.requireNonNull(dispatcher);
+        this.dispatcher = dispatcher.register(this::dispatchFully);
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        close();
+    }
+
+    @Override
+    public void close() throws Exception {
+        dispatcher.unregister(this::dispatchFully);
+    }
+
+    private void newResult () {
+        results.push(new CompletableFuture<List<V>>());
+        addResult = o -> {};
+    }
+    
+    public CompletableFuture<List<V>> dispatchResult () {
+        return results.peek();
+    }
+    
+    @Override
+    public CompletableFuture<List<V>> loadMany(List<K> keys, List<Object> keyContexts) {
+        addResult.accept(this);
+        return super.loadMany(keys, keyContexts); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public CompletableFuture<V> load(K key, Object keyContext) {
+        addResult.accept(this);
+        return super.load(key, keyContext);
+    }
+    
+    protected CompletableFuture<List<V>> dispatchFully () {
+        addResult = AutoDataLoader::newResult;
+//        return super.dispatch()
+//            .thenCompose(value -> {
+//                CompletableFuture<List<V>> result = results.peek();
+//                result.complete(value);
+//                return result;
+//            });
+        return deepDispatch()
+                .thenCompose(value -> {
+                    CompletableFuture<List<V>> result = results.peek();
+                    result.complete(value);
+                    return result;
+                });
+    }
+    
+    private CompletableFuture<List<V>> deepDispatch () {
+        addResult = AutoDataLoader::newResult;
+        return super.dispatch()
+            .thenCombine(dispatchDepth() > 0 ? deepDispatch() : completedFuture(emptyList()), 
+                (left, right) -> {
+                    left.addAll((List<V>)right);
+                    return left;
+                });
+    }
+    
+    @Override
+    public CompletableFuture<List<V>> dispatch() {
+        return dispatchResult();
+    }
+    
+    public List<V> dispatchAndJoin() {
+        return dispatchResult().join();
+//        return super.dispatchAndJoin();
+    }
+    
+    private class Result extends CompletableFuture<List<V>> {
+        @Override
+        public boolean complete(List<V> value) {
+            System.out.println("completing...value=" + value);
+            addValue(value);
+            if (dispatchDepth() == 0) {
+                System.out.println("completed! result=" + result);
+                return super.complete(result);
+            }
+            
+            return false;
+        }
+        
+        private void addValue (List<V> value) {
+            if (result == null)
+                result = value;
+            else 
+                result.addAll(value);
+        }
+        
+        private List<V> result;
+    }
+}

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -96,7 +96,7 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
     
     @Override
     public void run() {        
-        dispatchFully()
+        dispatch0()
             .thenAccept(value -> {
                 received.addAll(value);
                 int receivedSize = received.size();
@@ -112,17 +112,11 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
             });
     }
 
-    private CompletableFuture<List<V>> dispatchFully () {
+    private CompletableFuture<List<V>> dispatch0 () {
         int dispatchDepth = dispatchDepth();
         requested += dispatchDepth;
         LOGGER.trace("dispatchFully...dispatchDept={}, requested={}", dispatchDepth, requested);
-        return (dispatchDepth > 0)
-            ? super.dispatch()
-                .thenCombine(dispatchFully(), (value, temp) -> {
-                    value.addAll(temp);
-                    return value;
-                })
-            : completedFuture(emptyList());
+        return super.dispatch();
     }
     
     

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -42,7 +42,7 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
     }
     
     public AutoDataLoader(BatchLoader<K, V> batchLoadFunction, AutoDataLoaderOptions options) {
-        this(batchLoadFunction, options, options.getDispatcher());
+        this(batchLoadFunction, options, options.dispatcher());
     }
     
     private AutoDataLoader(BatchLoader<K, V> batchLoadFunction, AutoDataLoaderOptions options, Dispatcher dispatcher) {

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -96,7 +96,7 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
     
     @Override
     public void run() {        
-        dispatch0()
+        dispatchFully()
             .thenAccept(value -> {
                 received.addAll(value);
                 int receivedSize = received.size();
@@ -112,11 +112,17 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
             });
     }
 
-    private CompletableFuture<List<V>> dispatch0 () {
+    private CompletableFuture<List<V>> dispatchFully () {
         int dispatchDepth = dispatchDepth();
         requested += dispatchDepth;
         LOGGER.trace("dispatchFully...dispatchDept={}, requested={}", dispatchDepth, requested);
-        return super.dispatch();
+        return (dispatchDepth > 0)
+            ? super.dispatch()
+                .thenCombine(dispatchFully(), (value, temp) -> {
+                    value.addAll(temp);
+                    return value;
+                })
+            : completedFuture(emptyList());
     }
     
     

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -5,9 +5,7 @@
  */
 package org.dataloader.nextgen;
 
-import java.util.ArrayDeque;
 import static java.util.Collections.emptyList;
-import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +20,7 @@ import org.dataloader.DataLoader;
  */
 public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, AutoCloseable {
     private final Dispatcher dispatcher;
-    private final Deque<CompletableFuture<List<V>>> results = new ArrayDeque<>();
+    private volatile CompletableFuture<List<V>> result;
     private volatile Consumer<AutoDataLoader<K, V>> addResult;
     
     public AutoDataLoader(BatchLoader<K, V> batchLoadFunction) {
@@ -57,12 +55,12 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
     }
 
     private void newResult () {
-        results.push(new CompletableFuture<List<V>>());
+        result = new CompletableFuture<List<V>>();
         addResult = o -> {};
     }
     
     public CompletableFuture<List<V>> dispatchResult () {
-        return results.peek();
+        return result;
     }
     
     @Override

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoader.java
@@ -103,7 +103,7 @@ public class AutoDataLoader<K, V> extends DataLoader<K, V> implements Runnable, 
                 LOGGER.trace("completing...requested={}, received={}", requested, receivedSize);
                 if (requested == receivedSize) {
                     if (!result.complete(received)) {
-                        LOGGER.warn("attempt to complete already completed result");
+                        LOGGER.trace("attempt to complete already completed result");
                     }
 
                     resultCreator = AutoDataLoader::newResult;

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
@@ -149,17 +149,19 @@ public class AutoDataLoaderOptions extends DataLoaderOptions {
     }
     
     /**
+     * Retrieves Dispatcher instance configured on this data loader opitons
      * 
-     * @return 
+     * @return configured Dispatcher object
      */
-    public Dispatcher getDispatcher () {
+    public Dispatcher dispatcher () {
         return dispatcher;
     }
     
     /**
+     * Sets a Dispatcher to be used by AutoDataLoaders created with this object
      * 
-     * @param dispatcher
-     * @return 
+     * @param dispatcher new Dispatcher for these options
+     * @return this instance to allow method chaining
      */
     public AutoDataLoaderOptions setDispatcher (Dispatcher dispatcher) {
         this.dispatcher = dispatcher;

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.dataloader.nextgen;
+
+import org.dataloader.*;
+import org.dataloader.stats.StatisticsCollector;
+
+import java.util.function.Supplier;
+
+
+/**
+ * Configuration options for {@link AutoDataLoader} instances.
+ *
+ * @author <a href="https://github.com/gkesler/">Greg Kesler</a>
+ */
+public class AutoDataLoaderOptions extends DataLoaderOptions {
+    public static final Dispatcher SHARED_DISPATCHER = new Dispatcher();
+
+    private Dispatcher dispatcher;
+
+    /**
+     * Creates a new data loader options with default settings.
+     */
+    public AutoDataLoaderOptions() {
+        dispatcher = SHARED_DISPATCHER;
+    }
+
+    /**
+     * Clones the provided data loader options.
+     *
+     * @param other the other options instance
+     */
+    public AutoDataLoaderOptions(AutoDataLoaderOptions other) {
+        super(other);
+
+        this.dispatcher = other.dispatcher;
+    }
+
+    /**
+     * @return a new default data loader options that you can then customize
+     */
+    public static AutoDataLoaderOptions newOptions() {
+        return new AutoDataLoaderOptions();
+    }
+
+    /**
+     * Sets the option that determines whether batch loading is enabled.
+     *
+     * @param batchingEnabled {@code true} to enable batch loading, {@code false} otherwise
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setBatchingEnabled(boolean batchingEnabled) {
+        return (AutoDataLoaderOptions)super.setBatchingEnabled(batchingEnabled);
+    }
+
+    /**
+     * Sets the option that determines whether caching is enabled.
+     *
+     * @param cachingEnabled {@code true} to enable caching, {@code false} otherwise
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setCachingEnabled(boolean cachingEnabled) {
+        return (AutoDataLoaderOptions)super.setCachingEnabled(cachingEnabled);
+    }
+
+    /**
+     * Sets the option that determines whether exceptional values are cachedis enabled.
+     *
+     * @param cachingExceptionsEnabled {@code true} to enable caching exceptional values, {@code false} otherwise
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setCachingExceptionsEnabled(boolean cachingExceptionsEnabled) {
+        return (AutoDataLoaderOptions)super.setCachingExceptionsEnabled(cachingExceptionsEnabled);
+    }
+
+    /**
+     * Sets the function to use for creating the cache key, if caching is enabled.
+     *
+     * @param cacheKeyFunction the cache key function to use
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setCacheKeyFunction(CacheKey cacheKeyFunction) {
+        return (AutoDataLoaderOptions)super.setCacheKeyFunction(cacheKeyFunction);
+    }
+
+    /**
+     * Sets the cache map implementation to use for caching, if caching is enabled.
+     *
+     * @param cacheMap the cache map instance
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setCacheMap(CacheMap cacheMap) {
+        return (AutoDataLoaderOptions)super.setCacheMap(cacheMap);
+    }
+
+    /**
+     * Sets the maximum number of keys that will be presented to the {@link BatchLoader} function
+     * before they are split into multiple class
+     *
+     * @param maxBatchSize the maximum batch size
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setMaxBatchSize(int maxBatchSize) {
+        return (AutoDataLoaderOptions)super.setMaxBatchSize(maxBatchSize);
+    }
+
+    /**
+     * Sets the statistics collector supplier that will be used with these data loader options.  Since it uses
+     * the supplier pattern, you can create a new statistics collector on each call or you can reuse
+     * a common value
+     *
+     * @param statisticsCollector the statistics collector to use
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setStatisticsCollector(Supplier<StatisticsCollector> statisticsCollector) {
+        return (AutoDataLoaderOptions)super.setStatisticsCollector(statisticsCollector);
+    }
+
+    /**
+     * Sets the batch loader environment provider that will be used to give context to batch load functions
+     *
+     * @param contextProvider the batch loader context provider
+     *
+     * @return the data loader options for fluent coding
+     */
+    public AutoDataLoaderOptions setBatchLoaderContextProvider(BatchLoaderContextProvider contextProvider) {
+        return (AutoDataLoaderOptions)super.setBatchLoaderContextProvider(contextProvider);
+    }
+    
+    /**
+     * 
+     * @return 
+     */
+    public Dispatcher getDispatcher () {
+        return dispatcher;
+    }
+    
+    /**
+     * 
+     * @param dispatcher
+     * @return 
+     */
+    public AutoDataLoaderOptions setDispatcher (Dispatcher dispatcher) {
+        this.dispatcher = dispatcher;
+        return this;
+    }
+}

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
@@ -31,6 +31,7 @@ public class AutoDataLoaderOptions extends DataLoaderOptions {
     public static final Dispatcher SHARED_DISPATCHER = new Dispatcher();
 
     private Dispatcher dispatcher;
+    private boolean dispatchAndJoin = false;
 
     /**
      * Creates a new data loader options with default settings.
@@ -163,6 +164,15 @@ public class AutoDataLoaderOptions extends DataLoaderOptions {
      */
     public AutoDataLoaderOptions setDispatcher (Dispatcher dispatcher) {
         this.dispatcher = dispatcher;
+        return this;
+    }
+    
+    public boolean dispatchAndJoin () {
+        return dispatchAndJoin;
+    }
+    
+    public AutoDataLoaderOptions setDispatchAndJoin (boolean value) {
+        this.dispatchAndJoin = value;
         return this;
     }
 }

--- a/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
+++ b/src/main/java/org/dataloader/nextgen/AutoDataLoaderOptions.java
@@ -31,7 +31,6 @@ public class AutoDataLoaderOptions extends DataLoaderOptions {
     public static final Dispatcher SHARED_DISPATCHER = new Dispatcher();
 
     private Dispatcher dispatcher;
-    private boolean dispatchAndJoin = false;
 
     /**
      * Creates a new data loader options with default settings.
@@ -164,15 +163,6 @@ public class AutoDataLoaderOptions extends DataLoaderOptions {
      */
     public AutoDataLoaderOptions setDispatcher (Dispatcher dispatcher) {
         this.dispatcher = dispatcher;
-        return this;
-    }
-    
-    public boolean dispatchAndJoin () {
-        return dispatchAndJoin;
-    }
-    
-    public AutoDataLoaderOptions setDispatchAndJoin (boolean value) {
-        this.dispatchAndJoin = value;
         return this;
     }
 }

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -60,12 +60,13 @@ public class Dispatcher implements Runnable, AutoCloseable {
     private final Map<AutoDataLoader, Thread> dataLoaders = new WeakHashMap<>();
     private final Queue<Command> commands = new ConcurrentLinkedQueue<>();
     private final Executor executor;
-    private volatile int state = IDLE;
     
     private static final int IDLE = 0;
     private static final int RUNNING = 1;
     private static final int CLOSING = 2;
     private static final int CLOSED = 3;
+    
+    private volatile int state = IDLE;    
     private static final AtomicIntegerFieldUpdater<Dispatcher> STATE = AtomicIntegerFieldUpdater
         .newUpdater(Dispatcher.class, "state");
     

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -221,9 +221,12 @@ public class Dispatcher implements AutoCloseable {
         }
         
         public Command forkWith (Executor executor) {
-            return ForkJoinTask.inForkJoinPool()
-                ? (Command)fork()
-                : executeWith(executor);
+            if (ForkJoinTask.inForkJoinPool()) {
+                fork().quietlyJoin();
+                return this;                    
+            } else {
+                return executeWith(executor);
+            }
         }
         
         public Command executeWith (Executor executor) {

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -164,11 +164,10 @@ public class Dispatcher implements Runnable, AutoCloseable {
             LOGGER.debug("close requested...");
 
             int s;
-            while ((s = state) != CLOSED);
-        } else {
-            state = CLOSED;
+            while ((s = state) == CLOSING);
         }
 
+        state = CLOSED;
         LOGGER.debug("closed!");
     }
 

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import java.util.stream.Stream;
-import org.dataloader.DataLoader;
 
 /**
  *
@@ -64,23 +63,11 @@ public class Dispatcher extends RecursiveAction implements RunnableFuture<Void>,
         return this;
     }
     
-    public Dispatcher register (DataLoader dataLoader) {
-        Objects.requireNonNull(dataLoader);
-        
-        return register(dataLoader::dispatch);
-    }
-    
     public Dispatcher unregister (Runnable dispatcher) {
         Objects.requireNonNull(dispatcher);
         
         dispatchers.remove(dispatcher);
         return this;
-    }
-    
-    public Dispatcher unregister (DataLoader dataLoader) {
-        Objects.requireNonNull(dataLoader);
-        
-        return unregister(dataLoader::dispatch);
     }
     
     private static boolean isWaiting (Thread thread) {
@@ -169,9 +156,9 @@ public class Dispatcher extends RecursiveAction implements RunnableFuture<Void>,
 
             tasks
                 .stream()
-                .peek(Objects::requireNonNull)
-                .map(Runnable.class::cast)
-                .forEach(Runnable::run);
+                .map(Objects::requireNonNull)
+                .forEach(r -> ((Runnable)r).run())/*
+                .forEach(ForkJoinTask::quietlyJoin)*/;
 
             return tasks;
         }

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -180,10 +180,7 @@ public class Dispatcher implements AutoCloseable {
         @Override
         protected void execute() {
             // wait while thread is running
-            while (closing.compareAndSet(false, false) && 
-                    isRunning(owner)) {
-//                Thread.yield();
-            }
+            while (closing.compareAndSet(false, false) && isRunning(owner));
             
             // and now do the dispatch
             dataLoader.run();

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -222,8 +222,7 @@ public class Dispatcher implements AutoCloseable {
         
         public Command forkWith (Executor executor) {
             if (ForkJoinTask.inForkJoinPool()) {
-                fork().quietlyJoin();
-                return this;                    
+                return (Command)fork();
             } else {
                 return executeWith(executor);
             }

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.RecursiveAction;

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -1,0 +1,179 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.dataloader.nextgen;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.UnaryOperator;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import java.util.stream.Stream;
+import org.dataloader.DataLoader;
+
+/**
+ *
+ * @author <a href="https://github.com/gkesler/">Greg Kesler</a>
+ */
+public class Dispatcher extends RecursiveAction implements RunnableFuture<Void>, Executor, AutoCloseable {
+    private final AtomicBoolean running;
+    private final Map<Runnable, Thread> dispatchers = new ConcurrentHashMap<>();
+    private final Map<Thread, Collection<ForkJoinTask<?>>> pendingTasks = new ConcurrentHashMap<>();
+    private final UnaryOperator<Collection<ForkJoinTask<?>>> invokeAll;
+
+    public Dispatcher (Executor executor) {
+        this(executor, Invoker::invokeAll);
+    }
+    
+    public Dispatcher (ForkJoinPool executor) {
+        this(executor, ForkJoinTask::invokeAll);
+    }
+
+    public Dispatcher () {
+        this(ForkJoinPool.commonPool());
+    }
+    
+    private Dispatcher (Executor executor, UnaryOperator<Collection<ForkJoinTask<?>>> tasksInvoker) {
+        Objects.requireNonNull(executor);
+        Objects.requireNonNull(tasksInvoker);
+        
+        this.invokeAll = tasksInvoker;
+        this.running = new AtomicBoolean(true);
+                
+        executor.execute(this);
+    }
+
+    public Dispatcher register (Runnable dispatcher) {
+        Objects.requireNonNull(dispatcher);
+        
+        dispatchers.put(dispatcher, Thread.currentThread());
+        return this;
+    }
+    
+    public Dispatcher register (DataLoader dataLoader) {
+        Objects.requireNonNull(dataLoader);
+        
+        return register(dataLoader::dispatch);
+    }
+    
+    public Dispatcher unregister (Runnable dispatcher) {
+        Objects.requireNonNull(dispatcher);
+        
+        dispatchers.remove(dispatcher);
+        return this;
+    }
+    
+    public Dispatcher unregister (DataLoader dataLoader) {
+        Objects.requireNonNull(dataLoader);
+        
+        return unregister(dataLoader::dispatch);
+    }
+    
+    private static boolean isWaiting (Thread thread) {
+        switch (thread.getState()) {
+            case NEW:
+            case RUNNABLE:
+                return false;
+        }
+        
+        return true;
+    }
+    
+    private static <T> T ifNull (T value, T defaultValue) {
+        return (value == null)
+            ? defaultValue
+            : value;
+    }
+    
+    @Override
+    protected void compute() {
+        while (running.compareAndSet(true, true)) {
+            // first group dispatchers by their threads
+            Map<Thread, List<Runnable>> waiters = dispatchers
+                .entrySet()
+                .stream()
+                .filter(e -> isWaiting(e.getValue()))
+                // owning thread is waiting
+                .collect(groupingBy(Map.Entry::getValue, mapping(Map.Entry::getKey, toList())));
+            
+            // collect dispatchers for this thread first
+            // then collect pending tasks if any
+            List<ForkJoinTask<?>> tasks = waiters
+                .entrySet()
+                .stream()
+                .flatMap(e -> Stream
+                    .concat(e.getValue()
+                            .stream()
+                            .map(Dispatcher::wrap), 
+                        ifNull(pendingTasks.remove(e.getKey()), Collections.<ForkJoinTask<?>>emptyList())
+                            .stream()
+                    )
+                )
+                .collect(toList());
+            
+            // start tasks execution
+            invokeAll
+                .apply(tasks)
+                .forEach(ForkJoinTask::quietlyJoin);
+
+            // force yield to other threads
+            Thread.yield();
+        }
+    }
+    
+    @Override
+    public void run() {
+        invoke();
+    }
+    
+    @Override
+    public void execute(Runnable command) {
+        Objects.requireNonNull(command);
+        
+        pendingTasks
+            .computeIfAbsent(Thread.currentThread(), t -> new ArrayDeque<>())
+            .add(wrap(command));
+    }
+    
+    private static ForkJoinTask<?> wrap (Runnable r) {
+        return (r instanceof ForkJoinTask)
+            ? (ForkJoinTask<?>)r
+            : adapt(r);
+    }
+
+    @Override
+    public void close() {
+        // request to close
+        running.set(false);
+        // and wait for completion
+        quietlyJoin();
+    }
+    
+    private static class Invoker {
+        static <T extends ForkJoinTask<?>> Collection<T> invokeAll (Collection<T> tasks) {
+            Objects.requireNonNull(tasks);
+
+            tasks
+                .stream()
+                .peek(Objects::requireNonNull)
+                .map(Runnable.class::cast)
+                .forEach(Runnable::run);
+
+            return tasks;
+        }
+    }
+}

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -95,8 +95,6 @@ public class Dispatcher implements AutoCloseable {
 
     /**
      * Creates a new instance that uses ForkJoinPool.commonPool()
-     * 
-     * @param executor executor to run Dispatcher tasks
      */
     public Dispatcher () {
         this(ForkJoinPool.commonPool());

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.RecursiveAction;

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -80,7 +80,7 @@ public class Dispatcher extends RecursiveAction implements RunnableFuture<Void>,
         return true;
     }
     
-    private static <T> T ifNull (T value, T defaultValue) {
+    private static <T> T defaultIfNull (T value, T defaultValue) {
         return (value == null)
             ? defaultValue
             : value;
@@ -103,10 +103,11 @@ public class Dispatcher extends RecursiveAction implements RunnableFuture<Void>,
                 .entrySet()
                 .stream()
                 .flatMap(e -> Stream
-                    .concat(e.getValue()
+                    .concat(
+                        e.getValue()
                             .stream()
                             .map(Dispatcher::wrap), 
-                        ifNull(pendingTasks.remove(e.getKey()), Collections.<ForkJoinTask<?>>emptyList())
+                        defaultIfNull(pendingTasks.remove(e.getKey()), Collections.<ForkJoinTask<?>>emptyList())
                             .stream()
                     )
                 )

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -150,7 +150,7 @@ public class Dispatcher implements AutoCloseable {
      * @param dataLoader data loader to schedule dispatch
      */
     public void scheduleBatch (AutoDataLoader dataLoader) {
-        LOGGER.trace("dispatch requested for {}", dataLoader);
+        LOGGER.debug("dispatch requested for {}", dataLoader);
         request(new DispatchCommand(dataLoader));
     }
     
@@ -158,10 +158,10 @@ public class Dispatcher implements AutoCloseable {
         Objects.requireNonNull(command);
         
         if (running.compareAndSet(false, true)) {
-            LOGGER.trace("scheduling execution for {}", command);
+            LOGGER.debug("scheduling execution for {}", command);
             invoker.apply(command, executor);
         } else {
-            LOGGER.trace("enqued command {}", command);
+            LOGGER.debug("enqued command {}", command);
             commands.offer(command);
         }
     } 
@@ -178,7 +178,7 @@ public class Dispatcher implements AutoCloseable {
 
     @Override
     public void close() {
-        LOGGER.trace("close requested...");
+        LOGGER.debug("close requested...");
         // close executor
         executor = CLOSED_EXECUTOR;
         closing.set(true);
@@ -186,7 +186,7 @@ public class Dispatcher implements AutoCloseable {
         while (running.compareAndSet(true, true)) {
             Thread.yield();
         }
-        LOGGER.trace("closed!");
+        LOGGER.debug("closed!");
     }
     
     protected abstract class Command extends RecursiveAction implements RunnableFuture<Void> {
@@ -195,15 +195,15 @@ public class Dispatcher implements AutoCloseable {
         @Override
         protected void compute() {
             try {
-                LOGGER.trace("executing command {}", this);
+                LOGGER.debug("executing command {}", this);
                 execute();
             } finally {
                 Command next = next();
                 if (next != null) {
-                    LOGGER.trace("scheduling next command {}", next);
+                    LOGGER.debug("scheduling next command {}", next);
                     invoker.apply(next, executor);
                 } else {
-                    LOGGER.trace("no more commands");
+                    LOGGER.debug("no more commands");
                     running.lazySet(false);
                 }
                 LOGGER.debug("finished command {}", this);

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -145,7 +145,7 @@ public class Dispatcher implements AutoCloseable {
      * Requests to schedule batching for the specified data loader
      * @param dataLoader data loader to schedule dispatch
      */
-    public void addToBatch (AutoDataLoader dataLoader) {
+    public void scheduleBatch (AutoDataLoader dataLoader) {
         LOGGER.trace("dispatch requested for {}", dataLoader);
         request(new DispatchCommand(dataLoader));
     }

--- a/src/main/java/org/dataloader/nextgen/Dispatcher.java
+++ b/src/main/java/org/dataloader/nextgen/Dispatcher.java
@@ -17,7 +17,6 @@ import java.util.concurrent.RecursiveAction;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
-import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,14 +33,23 @@ import org.slf4j.LoggerFactory;
  * {@code 
  *    Dispatcher commonPoolDispatcher = new Dispatcher();
  *    BatchLoader<K, V> batchLoader = ...
- *    AutoDataLoader<K, V> commonPoolLoader = new AutoDataLoader<>(batchLoader, commonPoolDispatcher);
+ *    AutoDataLoader<K, V> commonPoolLoader = new AutoDataLoader<>(batchLoader, new AutoDataLoaderOptions());
  * }
  * 
  * To create AutoDataLoader that is limited to run on 1 thread use the folllowing code
  * {@code 
- *    Dispatcher commonPoolDispatcher = new Dispatcher(Executors.newSingleThreadExecutor());
+ *    Dispatcher singleThreadDispatcher = new Dispatcher(Executors.newSingleThreadExecutor());
  *    BatchLoader<K, V> batchLoader = ...
- *    AutoDataLoader<K, V> commonPoolLoader = new AutoDataLoader<>(batchLoader, commonPoolDispatcher);
+ *    AutoDataLoader<K, V> commonPoolLoader = new AutoDataLoader<>(batchLoader, singleThreadDispatcher);
+ * }
+ * 
+ * To create AutoDataLoader with DataLoaderOptions and to choose threading model, use the code
+ * below:
+ * {@code 
+ *    Dispatcher singleThreadDispatcher = new Dispatcher(Executors.newSingleThreadExecutor());
+ *    AutoDataLoaderOptions options = new AutoDataLoaderOptions().setDispatcher(singleThreadDispatcher);
+ *    BatchLoader<K, V> batchLoader = ...
+ *    AutoDataLoader<K, V> commonPoolLoader = new AutoDataLoader<>(batchLoader, options);
  * }
  * 
  * @see AutoDataLoader#load(java.lang.Object) 

--- a/src/test/java/org/dataloader/JsonObject.java
+++ b/src/test/java/org/dataloader/JsonObject.java
@@ -4,11 +4,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-class JsonObject {
+public class JsonObject {
 
     private final Map<String, Object> values;
 
-    JsonObject() {
+    public JsonObject() {
         values = new LinkedHashMap<>();
     }
 

--- a/src/test/java/org/dataloader/TestKit.java
+++ b/src/test/java/org/dataloader/TestKit.java
@@ -17,7 +17,7 @@ public class TestKit {
         return ints;
     }
 
-    static <V> CompletableFuture<V> futureError() {
+    public static <V> CompletableFuture<V> futureError() {
         return failedFuture(new IllegalStateException("Error"));
     }
 }

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -38,12 +38,9 @@ import static java.util.Collections.singletonList;
 import java.util.HashSet;
 import java.util.Set;
 import static java.util.concurrent.CompletableFuture.allOf;
-import java.util.concurrent.Executors;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.TestKit.listFrom;
 import static org.dataloader.impl.CompletableFutureKit.cause;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -51,7 +48,6 @@ import static org.hamcrest.Matchers.is;
 import org.junit.After;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -59,14 +55,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tests for {@link DataLoader}.
+ * Tests for {@link AutoDataLoader}.
  * <p>
  * The tests are a port of the existing tests in
  * the <a href="https://github.com/facebook/dataloader">facebook/dataloader</a> project.
  * <p>
  * Acknowledgments go to <a href="https://github.com/leebyron">Lee Byron</a> for providing excellent coverage.
  *
- * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
+ * @author <a href="https://github.com/gkesler/">Greg Kesler</a>
  */
 public class AutoDataLoaderTest {
     private Dispatcher dispatcher;

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -946,8 +946,10 @@ public class AutoDataLoaderTest {
 
         await().untilTrue(v4Called);
 
-        identityLoader.dispatchAndJoin();
+//        identityLoader.dispatchAndJoin();
 
+        // check number of elements in the loadCalls list
+        assertThat(loadCalls.size(), equalTo(1));
         assertThat(loadCalls, equalTo(
                 singletonList(asList("a", "b", "c", "d"))));
     }

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -1003,9 +1003,7 @@ public class AutoDataLoaderTest {
 //                        .stream()
 //                        .map(userManager::loadUserById)
 //                        .collect(Collectors.toList()));
-        AutoDataLoaderOptions options = new AutoDataLoaderOptions()
-            .setDispatchAndJoin(true);
-        AutoDataLoader<Long, User> userLoader = new AutoDataLoader<>(userBatchLoader, options, dispatcher);
+        AutoDataLoader<Long, User> userLoader = new AutoDataLoader<>(userBatchLoader, dispatcher);
 
         AtomicBoolean gandalfCalled = new AtomicBoolean(false);
         AtomicBoolean sarumanCalled = new AtomicBoolean(false);

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -975,9 +975,9 @@ public class AutoDataLoaderTest {
 
 //        identityLoader.dispatchAndJoin();
 
-        assertThat(loadCalls, equalTo(
-                singletonList(asList("a", "b", "c", "d"))));
-//        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
+//        assertThat(loadCalls, equalTo(
+//                singletonList(asList("a", "b", "c", "d"))));
+        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
     }
     
     @Test

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -975,9 +975,9 @@ public class AutoDataLoaderTest {
 
 //        identityLoader.dispatchAndJoin();
 
+        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
 //        assertThat(loadCalls, equalTo(
 //                singletonList(asList("a", "b", "c", "d"))));
-        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
     }
     
     @Test

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -38,6 +38,7 @@ import static java.util.Collections.singletonList;
 import java.util.HashSet;
 import java.util.Set;
 import static java.util.concurrent.CompletableFuture.allOf;
+import java.util.concurrent.Executors;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.TestKit.listFrom;
 import static org.dataloader.impl.CompletableFutureKit.cause;

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -971,14 +971,13 @@ public class AutoDataLoaderTest {
 
         LOGGER.debug("awaiting for v4Called == true ...");
         await().untilTrue(v4Called);
-//        await().until(d::isDone);
         LOGGER.debug("woke up!");
 
 //        identityLoader.dispatchAndJoin();
 
-//        assertThat(loadCalls, equalTo(
-//                singletonList(asList("a", "b", "c", "d"))));
-        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
+        assertThat(loadCalls, equalTo(
+                singletonList(asList("a", "b", "c", "d"))));
+//        assertThat(flatList(loadCalls), equalTo(asList("a", "b", "c", "d")));
     }
     
     @Test

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -1,0 +1,1094 @@
+/*
+ * Copyright (c) 2016 The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package org.dataloader.nextgen;
+
+import org.dataloader.*;
+import org.dataloader.fixtures.User;
+import org.dataloader.fixtures.UserManager;
+import org.dataloader.impl.CompletableFutureKit;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import java.util.HashSet;
+import java.util.Set;
+import static org.awaitility.Awaitility.await;
+import static org.dataloader.TestKit.listFrom;
+import static org.dataloader.impl.CompletableFutureKit.cause;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import org.junit.After;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Ignore;
+
+/**
+ * Tests for {@link DataLoader}.
+ * <p>
+ * The tests are a port of the existing tests in
+ * the <a href="https://github.com/facebook/dataloader">facebook/dataloader</a> project.
+ * <p>
+ * Acknowledgments go to <a href="https://github.com/leebyron">Lee Byron</a> for providing excellent coverage.
+ *
+ * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
+ */
+public class AutoDataLoaderTest {
+    private Dispatcher dispatcher;
+
+    @Before
+    public void setUp () throws Exception {
+        dispatcher = new Dispatcher();
+    }
+    
+    @After
+    public void tierDown () {
+        dispatcher.close();
+        dispatcher = null;
+    }
+    
+    @Test
+    public void should_Build_a_really_really_simple_data_loader() {
+        AtomicBoolean success = new AtomicBoolean();
+        DataLoader<Integer, Integer> identityLoader = new AutoDataLoader<>(keysAsValues(), dispatcher);
+
+        CompletionStage<Integer> future1 = identityLoader.load(1);
+
+        future1.thenAccept(value -> {
+            assertThat(value, equalTo(1));
+            success.set(true);
+        });
+//        identityLoader.dispatch();
+        await().untilAtomic(success, is(true));
+    }
+
+    @Test
+    public void should_Support_loading_multiple_keys_in_one_call() {
+        AtomicBoolean success = new AtomicBoolean();
+        DataLoader<Integer, Integer> identityLoader = new AutoDataLoader<>(keysAsValues(), dispatcher);
+
+        CompletionStage<List<Integer>> futureAll = identityLoader.loadMany(asList(1, 2));
+        futureAll.thenAccept(promisedValues -> {
+            assertThat(promisedValues.size(), is(2));
+            success.set(true);
+        });
+//        identityLoader.dispatch();
+        await().untilAtomic(success, is(true));
+        assertThat(futureAll.toCompletableFuture().join(), equalTo(asList(1, 2)));
+    }
+
+    @Test
+    public void should_Resolve_to_empty_list_when_no_keys_supplied() {
+        AtomicBoolean success = new AtomicBoolean();
+        DataLoader<Integer, Integer> identityLoader = new AutoDataLoader<>(keysAsValues(), dispatcher);
+        CompletableFuture<List<Integer>> futureEmpty = identityLoader.loadMany(emptyList());
+        futureEmpty.thenAccept(promisedValues -> {
+            assertThat(promisedValues.size(), is(0));
+            success.set(true);
+        });
+//        identityLoader.dispatch();
+        await().untilAtomic(success, is(true));
+        assertThat(futureEmpty.join(), empty());
+    }
+
+    @Test
+    public void should_Batch_multiple_requests() throws ExecutionException, InterruptedException {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> future1 = identityLoader.load(1);
+        CompletableFuture<Integer> future2 = identityLoader.load(2);
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo(1));
+        assertThat(future2.get(), equalTo(2));
+        assertThat(loadCalls, equalTo(singletonList(asList(1, 2))));
+    }
+
+    @Test
+    public void should_Coalesce_identical_requests() throws ExecutionException, InterruptedException {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> future1a = identityLoader.load(1);
+        CompletableFuture<Integer> future1b = identityLoader.load(1);
+        assertThat(future1a, equalTo(future1b));
+//        identityLoader.dispatch();
+
+        await().until(future1a::isDone);
+        assertThat(future1a.get(), equalTo(1));
+        assertThat(future1b.get(), equalTo(1));
+        assertThat(loadCalls, equalTo(singletonList(singletonList(1))));
+    }
+
+    @Test
+    public void should_Cache_repeated_requests() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future3 = identityLoader.load("C");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1a.isDone() && future3.isDone());
+        assertThat(future1a.get(), equalTo("A"));
+        assertThat(future3.get(), equalTo("C"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"), singletonList("C"))));
+
+        CompletableFuture<String> future1b = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+        CompletableFuture<String> future3a = identityLoader.load("C");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1b.isDone() && future2a.isDone() && future3a.isDone());
+        assertThat(future1b.get(), equalTo("A"));
+        assertThat(future2a.get(), equalTo("B"));
+        assertThat(future3a.get(), equalTo("C"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"), singletonList("C"))));
+    }
+
+    @Test
+    public void should_Not_redispatch_previous_load() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone());
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(asList(singletonList("A"), singletonList("B"))));
+    }
+
+    @Test
+    public void should_Cache_on_redispatch() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone());
+        CompletableFuture<List<String>> future2 = identityLoader.loadMany(asList("A", "B"));
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo(asList("A", "B")));
+        assertThat(loadCalls, equalTo(asList(singletonList("A"), singletonList("B"))));
+    }
+
+    @Test
+    public void should_Clear_single_value_in_loader() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
+
+        identityLoader.clear("A");
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1a.isDone() && future2a.isDone());
+        assertThat(future1a.get(), equalTo("A"));
+        assertThat(future2a.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"), singletonList("A"))));
+    }
+
+    @Test
+    public void should_Clear_all_values_in_loader() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
+
+        identityLoader.clearAll();
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1a.isDone() && future2a.isDone());
+        assertThat(future1a.get(), equalTo("A"));
+        assertThat(future2a.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"), asList("A", "B"))));
+    }
+
+    @Test
+    public void should_Allow_priming_the_cache() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        identityLoader.prime("A", "A");
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(singletonList("B"))));
+    }
+
+    @Test
+    public void should_Not_prime_keys_that_already_exist() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        AutoDataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        identityLoader.prime("A", "X");
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        CompletableFuture<List<String>> composite = identityLoader.dispatch();
+        CompletableFuture<List<String>> composite = identityLoader.dispatchResult();
+
+        await().until(composite::isDone);
+        assertThat(future1.get(), equalTo("X"));
+        assertThat(future2.get(), equalTo("B"));
+
+        identityLoader.prime("A", "Y");
+        identityLoader.prime("B", "Y");
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+//        CompletableFuture<List<String>> composite2 = identityLoader.dispatch();
+        CompletableFuture<List<String>> composite2 = identityLoader.dispatchResult();
+
+        await().until(composite2::isDone);
+        assertThat(future1a.get(), equalTo("X"));
+        assertThat(future2a.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(singletonList("B"))));
+    }
+
+    @Test
+    public void should_Allow_to_forcefully_prime_the_cache() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        AutoDataLoader<String, String> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        identityLoader.prime("A", "X");
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        CompletableFuture<List<String>> composite = identityLoader.dispatch();
+        CompletableFuture<List<String>> composite = identityLoader.dispatchResult();
+
+        await().until(composite::isDone);
+        assertThat(future1.get(), equalTo("X"));
+        assertThat(future2.get(), equalTo("B"));
+
+        identityLoader.clear("A").prime("A", "Y");
+        identityLoader.clear("B").prime("B", "Y");
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+//        CompletableFuture<List<String>> composite2 = identityLoader.dispatch();
+        CompletableFuture<List<String>> composite2 = identityLoader.dispatchResult();
+
+        await().until(composite2::isDone);
+        assertThat(future1a.get(), equalTo("Y"));
+        assertThat(future2a.get(), equalTo("Y"));
+        assertThat(loadCalls, equalTo(singletonList(singletonList("B"))));
+    }
+
+    @Test
+    public void should_not_Cache_failed_fetches_on_complete_failure() {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> errorLoader = idLoaderBlowsUps(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> future1 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+
+        CompletableFuture<Integer> future2 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(future2.isCompletedExceptionally(), is(true));
+        assertThat(cause(future2), instanceOf(IllegalStateException.class));
+        assertThat(loadCalls, equalTo(asList(singletonList(1), singletonList(1))));
+    }
+
+    @Test
+    public void should_Resolve_to_error_to_indicate_failure() throws ExecutionException, InterruptedException {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Object> evenLoader = idLoaderOddEvenExceptions(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Object> future1 = evenLoader.load(1);
+//        evenLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+
+        CompletableFuture<Object> future2 = evenLoader.load(2);
+//        evenLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(future2.get(), equalTo(2));
+        assertThat(loadCalls, equalTo(asList(singletonList(1), singletonList(2))));
+    }
+
+    // Accept any kind of key.
+
+    @Test
+    public void should_Represent_failures_and_successes_simultaneously() throws ExecutionException, InterruptedException {
+        AtomicBoolean success = new AtomicBoolean();
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        AutoDataLoader<Integer, Object> evenLoader = idLoaderOddEvenExceptions(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Object> future1 = evenLoader.load(1);
+        CompletableFuture<Object> future2 = evenLoader.load(2);
+        CompletableFuture<Object> future3 = evenLoader.load(3);
+        CompletableFuture<Object> future4 = evenLoader.load(4);
+//        CompletableFuture<List<Object>> result = evenLoader.dispatch();
+        CompletableFuture<List<Object>> result = evenLoader.dispatchResult();
+        result.thenAccept(promisedValues -> success.set(true));
+
+        await().untilAtomic(success, is(true));
+
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+        assertThat(future2.get(), equalTo(2));
+        assertThat(future3.isCompletedExceptionally(), is(true));
+        assertThat(future4.get(), equalTo(4));
+
+        assertThat(loadCalls, equalTo(singletonList(asList(1, 2, 3, 4))));
+    }
+
+    // Accepts options
+
+    @Test
+    public void should_Cache_failed_fetches() {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Object> errorLoader = idLoaderAllExceptions(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Object> future1 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+
+        CompletableFuture<Object> future2 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(future2.isCompletedExceptionally(), is(true));
+        assertThat(cause(future2), instanceOf(IllegalStateException.class));
+
+        assertThat(loadCalls, equalTo(singletonList(singletonList(1))));
+    }
+
+    @Test
+    public void should_NOT_Cache_failed_fetches_if_told_not_too() {
+        AutoDataLoaderOptions options = AutoDataLoaderOptions.newOptions().setCachingExceptionsEnabled(false);
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Object> errorLoader = idLoaderAllExceptions(options, loadCalls, dispatcher);
+
+        CompletableFuture<Object> future1 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+
+        CompletableFuture<Object> future2 = errorLoader.load(1);
+//        errorLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(future2.isCompletedExceptionally(), is(true));
+        assertThat(cause(future2), instanceOf(IllegalStateException.class));
+
+        assertThat(loadCalls, equalTo(asList(singletonList(1), singletonList(1))));
+    }
+
+
+    // Accepts object key in custom cacheKey function
+
+    @Test
+    public void should_Handle_priming_the_cache_with_an_error() {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        identityLoader.prime(1, new IllegalStateException("Error"));
+
+        CompletableFuture<Integer> future1 = identityLoader.load(1);
+//        identityLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+        assertThat(loadCalls, equalTo(emptyList()));
+    }
+
+    @Test
+    public void should_Clear_values_from_cache_after_errors() {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> errorLoader = idLoaderBlowsUps(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> future1 = errorLoader.load(1);
+        future1.handle((value, t) -> {
+            if (t != null) {
+                // Presumably determine if this error is transient, and only clear the cache in that case.
+                errorLoader.clear(1);
+            }
+            return null;
+        });
+//        errorLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        assertThat(cause(future1), instanceOf(IllegalStateException.class));
+
+        CompletableFuture<Integer> future2 = errorLoader.load(1);
+        future2.handle((value, t) -> {
+            if (t != null) {
+                // Again, only do this if you can determine the error is transient.
+                errorLoader.clear(1);
+            }
+            return null;
+        });
+//        errorLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(future2.isCompletedExceptionally(), is(true));
+        assertThat(cause(future2), instanceOf(IllegalStateException.class));
+        assertThat(loadCalls, equalTo(asList(singletonList(1), singletonList(1))));
+    }
+
+    @Test
+    public void should_Propagate_error_to_all_loads() {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> errorLoader = idLoaderBlowsUps(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> future1 = errorLoader.load(1);
+        CompletableFuture<Integer> future2 = errorLoader.load(2);
+//        errorLoader.dispatch();
+
+        await().until(future1::isDone);
+        assertThat(future1.isCompletedExceptionally(), is(true));
+        Throwable cause = cause(future1);
+        assert cause != null;
+        assertThat(cause, instanceOf(IllegalStateException.class));
+        assertThat(cause.getMessage(), equalTo("Error"));
+
+        await().until(future2::isDone);
+        cause = cause(future2);
+        assert cause != null;
+        assertThat(cause.getMessage(), equalTo(cause.getMessage()));
+        assertThat(loadCalls, equalTo(singletonList(asList(1, 2))));
+    }
+
+    @Test
+    public void should_Accept_objects_as_keys() {
+        List<Collection<Object>> loadCalls = new ArrayList<>();
+        AutoDataLoader<Object, Object> identityLoader = idLoader(new AutoDataLoaderOptions(), loadCalls, dispatcher);
+
+        Object keyA = new Object();
+        Object keyB = new Object();
+
+        // Fetches as expected
+
+        identityLoader.load(keyA);
+        identityLoader.load(keyB);
+
+//        identityLoader.dispatch().thenAccept(promisedValues -> {
+        await().until(identityLoader.dispatchResult()::isDone);
+        identityLoader.dispatchResult().thenAccept(promisedValues -> {
+            assertThat(promisedValues.get(0), equalTo(keyA));
+            assertThat(promisedValues.get(1), equalTo(keyB));
+        });
+
+        assertThat(loadCalls.size(), equalTo(1));
+        assertThat(loadCalls.get(0).size(), equalTo(2));
+        assertThat(loadCalls.get(0).toArray()[0], equalTo(keyA));
+        assertThat(loadCalls.get(0).toArray()[1], equalTo(keyB));
+
+        // Caching
+        identityLoader.clear(keyA);
+        //noinspection SuspiciousMethodCalls
+        loadCalls.remove(keyA);
+
+        identityLoader.load(keyA);
+        identityLoader.load(keyB);
+
+//        identityLoader.dispatch().thenAccept(promisedValues -> {
+        await().until(identityLoader.dispatchResult()::isDone);
+        identityLoader.dispatchResult().thenAccept(promisedValues -> {
+            assertThat(promisedValues.get(0), equalTo(keyA));
+            assertThat(identityLoader.getCacheKey(keyB), equalTo(keyB));
+        });
+
+        assertThat(loadCalls.size(), equalTo(2));
+        assertThat(loadCalls.get(1).size(), equalTo(1));
+        assertThat(loadCalls.get(1).toArray()[0], equalTo(keyA));
+    }
+
+    @Test
+    public void should_Disable_caching() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader =
+                idLoader(newOptions().setCachingEnabled(false), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
+
+        CompletableFuture<String> future1a = identityLoader.load("A");
+        CompletableFuture<String> future3 = identityLoader.load("C");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1a.isDone() && future3.isDone());
+        assertThat(future1a.get(), equalTo("A"));
+        assertThat(future3.get(), equalTo("C"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"), asList("A", "C"))));
+
+        CompletableFuture<String> future1b = identityLoader.load("A");
+        CompletableFuture<String> future2a = identityLoader.load("B");
+        CompletableFuture<String> future3a = identityLoader.load("C");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1b.isDone() && future2a.isDone() && future3a.isDone());
+        assertThat(future1b.get(), equalTo("A"));
+        assertThat(future2a.get(), equalTo("B"));
+        assertThat(future3a.get(), equalTo("C"));
+        assertThat(loadCalls, equalTo(asList(asList("A", "B"),
+                asList("A", "C"), asList("A", "B", "C"))));
+    }
+
+    @Test
+    public void should_work_with_duplicate_keys_when_caching_disabled() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader =
+                idLoader(newOptions().setCachingEnabled(false), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+        CompletableFuture<String> future3 = identityLoader.load("A");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone() && future3.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(future3.get(), equalTo("A"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B", "A"))));
+    }
+
+    @Test
+    public void should_work_with_duplicate_keys_when_caching_enabled() throws ExecutionException, InterruptedException {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader =
+                idLoader(newOptions().setCachingEnabled(true), loadCalls, dispatcher);
+
+        CompletableFuture<String> future1 = identityLoader.load("A");
+        CompletableFuture<String> future2 = identityLoader.load("B");
+        CompletableFuture<String> future3 = identityLoader.load("A");
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone() && future3.isDone());
+        assertThat(future1.get(), equalTo("A"));
+        assertThat(future2.get(), equalTo("B"));
+        assertThat(future3.get(), equalTo("A"));
+        assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
+    }
+
+    // It is resilient to job queue ordering
+
+    @Test
+    public void should_Accept_objects_with_a_complex_key() throws ExecutionException, InterruptedException {
+        List<Collection<JsonObject>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoader<JsonObject, Integer> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        JsonObject key1 = new JsonObject().put("id", 123);
+        JsonObject key2 = new JsonObject().put("id", 123);
+
+        CompletableFuture<Integer> future1 = identityLoader.load(key1);
+        CompletableFuture<Integer> future2 = identityLoader.load(key2);
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(loadCalls, equalTo(singletonList(singletonList(key1))));
+        assertThat(future1.get(), equalTo(key1));
+        assertThat(future2.get(), equalTo(key1));
+    }
+
+    // Helper methods
+
+    @Test
+    public void should_Clear_objects_with_complex_key() throws ExecutionException, InterruptedException {
+        List<Collection<JsonObject>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoader<JsonObject, Integer> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        JsonObject key1 = new JsonObject().put("id", 123);
+        JsonObject key2 = new JsonObject().put("id", 123);
+
+        CompletableFuture<Integer> future1 = identityLoader.load(key1);
+//        identityLoader.dispatch();
+
+        await().until(future1::isDone);
+        identityLoader.clear(key2); // clear equivalent object key
+
+        CompletableFuture<Integer> future2 = identityLoader.load(key1);
+//        identityLoader.dispatch();
+
+        await().until(future2::isDone);
+        assertThat(loadCalls, equalTo(asList(singletonList(key1), singletonList(key1))));
+        assertThat(future1.get(), equalTo(key1));
+        assertThat(future2.get(), equalTo(key1));
+    }
+
+    @Test
+    public void should_Accept_objects_with_different_order_of_keys() throws ExecutionException, InterruptedException {
+        List<Collection<JsonObject>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoader<JsonObject, Integer> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        JsonObject key1 = new JsonObject().put("a", 123).put("b", 321);
+        JsonObject key2 = new JsonObject().put("b", 321).put("a", 123);
+
+        // Fetches as expected
+
+        CompletableFuture<Integer> future1 = identityLoader.load(key1);
+        CompletableFuture<Integer> future2 = identityLoader.load(key2);
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(loadCalls, equalTo(singletonList(singletonList(key1))));
+        assertThat(loadCalls.size(), equalTo(1));
+        assertThat(future1.get(), equalTo(key1));
+        assertThat(future2.get(), equalTo(key1));
+    }
+
+    @Test
+    public void should_Allow_priming_the_cache_with_an_object_key() throws ExecutionException, InterruptedException {
+        List<Collection<JsonObject>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoader<JsonObject, JsonObject> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        JsonObject key1 = new JsonObject().put("id", 123);
+        JsonObject key2 = new JsonObject().put("id", 123);
+
+        identityLoader.prime(key1, key1);
+
+        CompletableFuture<JsonObject> future1 = identityLoader.load(key1);
+        CompletableFuture<JsonObject> future2 = identityLoader.load(key2);
+//        identityLoader.dispatch();
+
+        await().until(() -> future1.isDone() && future2.isDone());
+        assertThat(loadCalls, equalTo(emptyList()));
+        assertThat(future1.get(), equalTo(key1));
+        assertThat(future2.get(), equalTo(key1));
+    }
+
+    @Test
+    public void should_Accept_a_custom_cache_map_implementation() throws ExecutionException, InterruptedException {
+        CustomCacheMap customMap = new CustomCacheMap();
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setCacheMap(customMap);
+        AutoDataLoader<String, String> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        // Fetches as expected
+
+        CompletableFuture future1 = identityLoader.load("a");
+        CompletableFuture future2 = identityLoader.load("b");
+//        CompletableFuture<List<String>> composite = identityLoader.dispatch();
+        CompletableFuture<List<String>> composite = identityLoader.dispatchResult();
+
+        await().until(composite::isDone);
+        assertThat(future1.get(), equalTo("a"));
+        assertThat(future2.get(), equalTo("b"));
+
+        assertThat(loadCalls, equalTo(singletonList(asList("a", "b"))));
+        assertArrayEquals(customMap.stash.keySet().toArray(), asList("a", "b").toArray());
+
+        CompletableFuture future3 = identityLoader.load("c");
+        CompletableFuture future2a = identityLoader.load("b");
+//        composite = identityLoader.dispatch();
+        composite = identityLoader.dispatchResult();
+
+        await().until(composite::isDone);
+        assertThat(future3.get(), equalTo("c"));
+        assertThat(future2a.get(), equalTo("b"));
+
+        assertThat(loadCalls, equalTo(asList(asList("a", "b"), singletonList("c"))));
+        assertArrayEquals(customMap.stash.keySet().toArray(), asList("a", "b", "c").toArray());
+
+        // Supports clear
+
+        identityLoader.clear("b");
+        assertArrayEquals(customMap.stash.keySet().toArray(), asList("a", "c").toArray());
+
+        CompletableFuture future2b = identityLoader.load("b");
+//        composite = identityLoader.dispatch();
+        composite = identityLoader.dispatchResult();
+
+        await().until(composite::isDone);
+        assertThat(future2b.get(), equalTo("b"));
+        assertThat(loadCalls, equalTo(asList(asList("a", "b"),
+                singletonList("c"), singletonList("b"))));
+        assertArrayEquals(customMap.stash.keySet().toArray(), asList("a", "c", "b").toArray());
+
+        // Supports clear all
+
+        identityLoader.clearAll();
+        assertArrayEquals(customMap.stash.keySet().toArray(), emptyList().toArray());
+    }
+
+    @Test
+    public void batching_disabled_should_dispatch_immediately() throws Exception {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setBatchingEnabled(false);
+        DataLoader<String, String> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        CompletableFuture<String> fa = identityLoader.load("A");
+        CompletableFuture<String> fb = identityLoader.load("B");
+
+        // caching is on still
+        CompletableFuture<String> fa1 = identityLoader.load("A");
+        CompletableFuture<String> fb1 = identityLoader.load("B");
+
+        List<String> values = CompletableFutureKit.allOf(asList(fa, fb, fa1, fb1)).join();
+
+        assertThat(fa.join(), equalTo("A"));
+        assertThat(fb.join(), equalTo("B"));
+        assertThat(fa1.join(), equalTo("A"));
+        assertThat(fb1.join(), equalTo("B"));
+
+        assertThat(values, equalTo(asList("A", "B", "A", "B")));
+
+        assertThat(loadCalls, equalTo(asList(
+                singletonList("A"),
+                singletonList("B"))));
+
+    }
+
+    @Test
+    public void batching_disabled_and_caching_disabled_should_dispatch_immediately_and_forget() throws Exception {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        AutoDataLoaderOptions options = newOptions().setBatchingEnabled(false).setCachingEnabled(false);
+        DataLoader<String, String> identityLoader = idLoader(options, loadCalls, dispatcher);
+
+        CompletableFuture<String> fa = identityLoader.load("A");
+        CompletableFuture<String> fb = identityLoader.load("B");
+
+        // caching is off
+        CompletableFuture<String> fa1 = identityLoader.load("A");
+        CompletableFuture<String> fb1 = identityLoader.load("B");
+
+        List<String> values = CompletableFutureKit.allOf(asList(fa, fb, fa1, fb1)).join();
+
+        assertThat(fa.join(), equalTo("A"));
+        assertThat(fb.join(), equalTo("B"));
+        assertThat(fa1.join(), equalTo("A"));
+        assertThat(fb1.join(), equalTo("B"));
+
+        assertThat(values, equalTo(asList("A", "B", "A", "B")));
+
+        assertThat(loadCalls, equalTo(asList(
+                singletonList("A"),
+                singletonList("B"),
+                singletonList("A"),
+                singletonList("B")
+        )));
+
+    }
+
+    @Test
+    public void batches_multiple_requests_with_max_batch_size() throws Exception {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        DataLoader<Integer, Integer> identityLoader = idLoader(newOptions().setMaxBatchSize(2), loadCalls, dispatcher);
+
+        CompletableFuture<Integer> f1 = identityLoader.load(1);
+        CompletableFuture<Integer> f2 = identityLoader.load(2);
+        CompletableFuture<Integer> f3 = identityLoader.load(3);
+
+//        identityLoader.dispatch();
+
+        CompletableFuture.allOf(f1, f2, f3).join();
+
+        assertThat(f1.join(), equalTo(1));
+        assertThat(f2.join(), equalTo(2));
+        assertThat(f3.join(), equalTo(3));
+
+        assertThat(loadCalls, equalTo(asList(asList(1, 2), singletonList(3))));
+
+    }
+
+    @Test
+    public void can_split_max_batch_sizes_correctly() throws Exception {
+        List<Collection<Integer>> loadCalls = new ArrayList<>();
+        AutoDataLoader<Integer, Integer> identityLoader = idLoader(newOptions().setMaxBatchSize(5), loadCalls, dispatcher);
+
+        for (int i = 0; i < 21; i++) {
+            identityLoader.load(i);
+        }
+        List<Collection<Integer>> expectedCalls = new ArrayList<>();
+        expectedCalls.add(listFrom(0, 5));
+        expectedCalls.add(listFrom(5, 10));
+        expectedCalls.add(listFrom(10, 15));
+        expectedCalls.add(listFrom(15, 20));
+        expectedCalls.add(listFrom(20, 21));
+
+//        List<Integer> result = identityLoader.dispatch().join();
+        List<Integer> result = identityLoader.dispatchResult().join();
+
+        assertThat(result, equalTo(listFrom(0, 21)));
+        assertThat(loadCalls, equalTo(expectedCalls));
+
+    }
+
+    @Test
+    public void should_Batch_loads_occurring_within_futures() {
+        List<Collection<String>> loadCalls = new ArrayList<>();
+        DataLoader<String, String> identityLoader = idLoader(newOptions(), loadCalls, dispatcher);
+
+        Supplier<Object> nullValue = () -> null;
+
+        AtomicBoolean v4Called = new AtomicBoolean();
+
+        CompletableFuture.supplyAsync(nullValue).thenAccept(v1 -> {
+            identityLoader.load("a");
+            CompletableFuture.supplyAsync(nullValue).thenAccept(v2 -> {
+                identityLoader.load("b");
+                CompletableFuture.supplyAsync(nullValue).thenAccept(v3 -> {
+                    identityLoader.load("c");
+                    CompletableFuture.supplyAsync(nullValue).thenAccept(
+                            v4 -> {
+                                identityLoader.load("d");
+                                v4Called.set(true);
+                            });
+                });
+            });
+        });
+
+        await().untilTrue(v4Called);
+
+        identityLoader.dispatchAndJoin();
+
+        assertThat(loadCalls, equalTo(
+                singletonList(asList("a", "b", "c", "d"))));
+    }
+
+    @Test
+    public void can_call_a_loader_from_a_loader() throws Exception {
+//        List<Collection<String>> deepLoadCalls = new ArrayList<>();
+        Set<String> deepLoadCalls = new HashSet<>();
+        DataLoader<String, String> deepLoader = new AutoDataLoader(keys -> {
+//            deepLoadCalls.add(keys);
+            deepLoadCalls.addAll(keys);
+            return CompletableFuture.completedFuture(keys);
+        }, dispatcher);
+
+        List<Collection<String>> aLoadCalls = new ArrayList<>();
+        DataLoader<String, String> aLoader = new AutoDataLoader<>(keys -> {
+            aLoadCalls.add(keys);
+            return deepLoader.loadMany(keys);
+        }, dispatcher);
+
+        List<Collection<String>> bLoadCalls = new ArrayList<>();
+        DataLoader<String, String> bLoader = new AutoDataLoader<>(keys -> {
+            bLoadCalls.add(keys);
+            return deepLoader.loadMany(keys);
+        }, dispatcher);
+
+        CompletableFuture<String> a1 = aLoader.load("A1");
+        CompletableFuture<String> a2 = aLoader.load("A2");
+        CompletableFuture<String> b1 = bLoader.load("B1");
+        CompletableFuture<String> b2 = bLoader.load("B2");
+
+        CompletableFuture.allOf(
+                aLoader.dispatch(),
+                deepLoader.dispatch(),
+                bLoader.dispatch(),
+                deepLoader.dispatch()
+        ).join();
+
+        assertThat(a1.get(), equalTo("A1"));
+        assertThat(a2.get(), equalTo("A2"));
+        assertThat(b1.get(), equalTo("B1"));
+        assertThat(b2.get(), equalTo("B2"));
+
+        assertThat(aLoadCalls, equalTo(
+                singletonList(asList("A1", "A2"))));
+
+        assertThat(bLoadCalls, equalTo(
+                singletonList(asList("B1", "B2"))));
+
+//        assertThat(deepLoadCalls, equalTo(
+//                asList(asList("A1", "A2"), asList("B1", "B2"))));
+        assertThat(deepLoadCalls, equalTo(new HashSet<>(asList("A1", "A2", "B1", "B2"))));
+    }
+
+    @Test
+    @Ignore
+    public void should_allow_composition_of_data_loader_calls() throws Exception {
+        UserManager userManager = new UserManager();
+
+        BatchLoader<Long, User> userBatchLoader = userIds -> CompletableFuture
+                .supplyAsync(() -> userIds
+                        .stream()
+                        .map(userManager::loadUserById)
+                        .collect(Collectors.toList()));
+        AutoDataLoader<Long, User> userLoader = new AutoDataLoader<>(userBatchLoader, dispatcher);
+
+        AtomicBoolean gandalfCalled = new AtomicBoolean(false);
+        AtomicBoolean sarumanCalled = new AtomicBoolean(false);
+
+        userLoader.load(1L)
+                .thenAccept(user -> userLoader.load(user.getInvitedByID())
+                        .thenAccept(invitedBy -> {
+                            gandalfCalled.set(true);
+                            assertThat(invitedBy.getName(), equalTo("Manwë"));
+                        }));
+
+        userLoader.load(2L)
+                .thenAccept(user -> userLoader.load(user.getInvitedByID())
+                        .thenAccept(invitedBy -> {
+                            sarumanCalled.set(true);
+                            assertThat(invitedBy.getName(), equalTo("Aulë"));
+                        }));
+
+//        List<User> allResults = userLoader.dispatchAndJoin();
+//        System.out.println("allResults=" + allResults);
+
+        await().untilTrue(gandalfCalled);
+        await().untilTrue(sarumanCalled);
+        
+        List<User> allResults = userLoader.dispatch().join();
+        System.out.println("allResults=" + allResults);
+        assertThat(allResults.size(), equalTo(4));
+    }
+
+
+    private static CacheKey<JsonObject> getJsonObjectCacheMapFn() {
+        return key -> key.stream()
+                .map(entry -> entry.getKey() + ":" + entry.getValue())
+                .sorted()
+                .collect(Collectors.joining());
+    }
+
+    private static <K, V> AutoDataLoader<K, V> idLoader(AutoDataLoaderOptions options, List<Collection<K>> loadCalls, Dispatcher dispatcher) {
+        return new AutoDataLoader<>(keys -> {
+            loadCalls.add(new ArrayList<>(keys));
+            @SuppressWarnings("unchecked")
+            List<V> values = keys.stream()
+                    .map(k -> (V) k)
+                    .collect(Collectors.toList());
+            return CompletableFuture.completedFuture(values);
+        }, options, dispatcher);
+    }
+
+    private static <K, V> AutoDataLoader<K, V> idLoaderBlowsUps(
+            AutoDataLoaderOptions options, List<Collection<K>> loadCalls, Dispatcher dispatcher) {
+        return new AutoDataLoader<>(keys -> {
+            loadCalls.add(new ArrayList<>(keys));
+            return TestKit.futureError();
+        }, options, dispatcher);
+    }
+
+    private static <K> AutoDataLoader<K, Object> idLoaderAllExceptions(
+            AutoDataLoaderOptions options, List<Collection<K>> loadCalls, Dispatcher dispatcher) {
+        return new AutoDataLoader<>(keys -> {
+            loadCalls.add(new ArrayList<>(keys));
+
+            List<Object> errors = keys.stream().map(k -> new IllegalStateException("Error")).collect(Collectors.toList());
+            return CompletableFuture.completedFuture(errors);
+        }, options, dispatcher);
+    }
+
+    private static AutoDataLoader<Integer, Object> idLoaderOddEvenExceptions(
+            AutoDataLoaderOptions options, List<Collection<Integer>> loadCalls, Dispatcher dispatcher) {
+        return new AutoDataLoader<>(keys -> {
+            loadCalls.add(new ArrayList<>(keys));
+
+            List<Object> errors = new ArrayList<>();
+            for (Integer key : keys) {
+                if (key % 2 == 0) {
+                    errors.add(key);
+                } else {
+                    errors.add(new IllegalStateException("Error"));
+                }
+            }
+            return CompletableFuture.completedFuture(errors);
+        }, options, dispatcher);
+    }
+
+
+    private <T> BatchLoader<T, T> keysAsValues() {
+        return CompletableFuture::completedFuture;
+    }
+
+    private static AutoDataLoaderOptions newOptions () {
+        return new AutoDataLoaderOptions();
+    }
+}
+

--- a/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
+++ b/src/test/java/org/dataloader/nextgen/AutoDataLoaderTest.java
@@ -964,13 +964,18 @@ public class AutoDataLoaderTest {
         CompletableFuture<String> a2 = aLoader.load("A2");
         CompletableFuture<String> b1 = bLoader.load("B1");
         CompletableFuture<String> b2 = bLoader.load("B2");
+//
+//        CompletableFuture.allOf(
+//                aLoader.dispatch(),
+//                deepLoader.dispatch(),
+//                bLoader.dispatch(),
+//                deepLoader.dispatch()
+//        ).join();
 
-        CompletableFuture.allOf(
-                aLoader.dispatch(),
-                deepLoader.dispatch(),
-                bLoader.dispatch(),
-                deepLoader.dispatch()
-        ).join();
+        await().until(a1::isDone);
+        await().until(a2::isDone);
+        await().until(b1::isDone);
+        await().until(b2::isDone);
 
         assertThat(a1.get(), equalTo("A1"));
         assertThat(a2.get(), equalTo("A2"));
@@ -989,7 +994,6 @@ public class AutoDataLoaderTest {
     }
 
     @Test
-    @Ignore
     public void should_allow_composition_of_data_loader_calls() throws Exception {
         UserManager userManager = new UserManager();
 
@@ -1009,6 +1013,13 @@ public class AutoDataLoaderTest {
                             gandalfCalled.set(true);
                             assertThat(invitedBy.getName(), equalTo("Manwë"));
                         }));
+//
+//        userLoader.load(1L)
+//                .thenCompose(user -> userLoader.load(user.getInvitedByID()))                
+//                .thenAccept(invitedBy -> {
+//                    gandalfCalled.set(true);
+//                    assertThat(invitedBy, equalTo("Manwë"));
+//                });
 
         userLoader.load(2L)
                 .thenAccept(user -> userLoader.load(user.getInvitedByID())
@@ -1016,6 +1027,20 @@ public class AutoDataLoaderTest {
                             sarumanCalled.set(true);
                             assertThat(invitedBy.getName(), equalTo("Aulë"));
                         }));
+//
+//        userLoader.load(2L)
+//                .thenCompose(user -> userLoader.load(user.getInvitedByID()))
+//                .thenAccept(invitedBy -> {
+//                    sarumanCalled.set(true);
+//                    assertThat(invitedBy.getName(), equalTo("Aulë"));
+//                });
+//
+//        userLoader.load(3L)
+//                .thenAccept(user -> userLoader.load(user.getInvitedByID())
+//                        .thenAccept(invitedBy -> {
+//                            sarumanCalled.set(true);
+//                            assertThat(invitedBy.getName(), equalTo("Oromë"));
+//                        }));
 
 //        List<User> allResults = userLoader.dispatchAndJoin();
 //        System.out.println("allResults=" + allResults);


### PR DESCRIPTION
Following our twitter conversation with @andimarek I have created a POC demonstrating an ability to trigger DataLoader dispatch automatically when the requestor (client) thread blocks on the DataLoader promises. 

In the current state, DataLoader fulfills load promises when `DataLoader.dispatch()` method is explicitly triggered. This to the great extent couples client code and GraphQL engine. In order to trigger `DataLoader.dispatch()` outside a client `DataFetcher`, a client needs to configure DataLoader aware `Instrumentation`, either supplied by the GraphQL framework or provided by the client, which is not a trivial exercise.

The main idea of automatic dispatch mechanism is to asynchronously check when client thread enters waiting (actually, not `RUNNABLE`) state and launch DataLoader dispatch process. Upon completion, the dispatch task is either destroyed or returned back to the thread pool where it was taken from. To minimize resource contention, the dispatch thread is not running permanently. Client can supply his own `Executor` to fully control thread usage.
If not `Executor` is not configured explicitly, the common `ForkJoinPool` is used. It is always available, lightweight and can handle large amount of tasks without resource contention. `CompletableFuture` xxxAsync methods by default use common pool to complete asynchronously.

The main usage pattern is:
```java
import org.dataloader.nextgen.DataLoader;

...
BatchLoader<K, V> batchLoader = ...
DataLoader<K, V> dataLoader = new AutoDataLoader<>(batchLoader);
CompletableFuture<V> f1 = dataLoader.load(key1);
CompletableFuture<V> f2 = dataLoader.load(key2);

// note, no dispatch
V v1 = f1.get();
V v2 = f2.get();
```

This is an attempt to match NodeJS DataLoader capabilities. 

Here is a sequence diagram illustrating automatic dispatch.
![image](https://user-images.githubusercontent.com/11729102/60311889-fecd4200-990d-11e9-970d-fb326eca019f.png)

@bbakerman @bbakerman WDYT?