### PR TITLE
Ability to atomically compute a data loader if absent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: false
 

--- a/src/main/java/org/dataloader/DataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/DataLoaderRegistry.java
@@ -1,13 +1,13 @@
 package org.dataloader;
 
-import org.dataloader.stats.Statistics;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.dataloader.stats.Statistics;
 
 /**
  * This allows data loaders to be registered together into a single place so
@@ -28,6 +28,26 @@ public class DataLoaderRegistry {
     public DataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader) {
         dataLoaders.put(key, dataLoader);
         return this;
+    }
+
+    /**
+     * Computes a data loader if absent or return it if it was
+     * already registered at that key.
+     *
+     * Note: The entire method invocation is performed atomically,
+     * so the function is applied at most once per key.
+     *
+     * @param key the key of the data loader
+     * @param mappingFunction the function to compute a data loader
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     *
+     * @return a data loader
+     */
+    @SuppressWarnings("unchecked")
+    public <K, V> DataLoader<K, V> computeIfAbsent(final String key,
+                                                   final Function<String, DataLoader<?, ?>> mappingFunction) {
+        return (DataLoader<K, V>) dataLoaders.computeIfAbsent(key, mappingFunction);
     }
 
     /**

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -1,9 +1,8 @@
 package org.dataloader;
 
+import java.util.concurrent.CompletableFuture;
 import org.dataloader.stats.Statistics;
 import org.junit.Test;
-
-import java.util.concurrent.CompletableFuture;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
@@ -101,4 +100,35 @@ public class DataLoaderRegistryTest {
         assertThat(statistics.getLoadErrorCount(), equalTo(0L));
         assertThat(statistics.getBatchLoadExceptionCount(), equalTo(0L));
     }
+
+    @Test
+    public void computeIfAbsent_creates_a_data_loader_if_there_was_no_value_at_key() {
+
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+
+        DataLoader<Object, Object> dlA = new DataLoader<>(identityBatchLoader);
+        DataLoader<Object, Object> registered = registry.computeIfAbsent("a", (key) -> dlA);
+
+        assertThat(registered, equalTo(dlA));
+        assertThat(registry.getKeys(), hasItems("a"));
+        assertThat(registry.getDataLoaders(), hasItems(dlA));
+    }
+
+    @Test
+    public void computeIfAbsent_returns_an_existing_data_loader_if_there_was_a_value_at_key() {
+
+        DataLoaderRegistry registry = new DataLoaderRegistry();
+
+        DataLoader<Object, Object> dlA = new DataLoader<>(identityBatchLoader);
+        registry.computeIfAbsent("a", (key) -> dlA);
+
+        // register again at same key
+        DataLoader<Object, Object> dlA2 = new DataLoader<>(identityBatchLoader);
+        DataLoader<Object, Object> registered = registry.computeIfAbsent("a", (key) -> dlA2);
+
+        assertThat(registered, equalTo(dlA));
+        assertThat(registry.getKeys(), hasItems("a"));
+        assertThat(registry.getDataLoaders(), hasItems(dlA));
+    }
+
 }


### PR DESCRIPTION
## Description 
I use `java-dataloader` in coordination of `graphql-java`. I'm running into a use case where I need to lazily construct and register data loaders only if they don't exist already in the registry. 

Currently, there is no exposed way to perform this action atomically through the `DataLoaderRegistry` since it rightfully encapsulates its concurrent hash map.

This PR exposes this capability. 

## Testing
unit tests covering the new method. 
Note: Any thoughts about adding Spock to the mix later?
