### PR TITLE
Adding queued entries following cache clear

### DIFF
--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -527,6 +527,7 @@ public class DataLoader<K, V> {
         Object cacheKey = getCacheKey(key);
         synchronized (this) {
             futureCache.delete(cacheKey);
+            helper.addQueuedEntries();
         }
         return this;
     }
@@ -539,6 +540,7 @@ public class DataLoader<K, V> {
     public DataLoader<K, V> clearAll() {
         synchronized (this) {
             futureCache.clear();
+            helper.addQueuedEntries();
         }
         return this;
     }

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -348,4 +348,16 @@ class DataLoaderHelper<K, V> {
             return loaderQueue.size();
         }
     }
+    
+	void addQueuedEntries() {
+		synchronized (dataLoader) {
+			if (! loaderOptions.cachingEnabled()) {
+				return;
+			}
+			
+			this.loaderQueue.forEach(action -> {
+				futureCache.set(action.getKey(), action.getValue());
+			});
+		}
+	}
 }


### PR DESCRIPTION
We are using dynamoDB with this library.
DynamoDB will error if one batch request contains duplicate ids.
And ideally with the cache enabled this does not happen

When we insert an entity into the database we clear that id from the dataloader cache.
If that Id has already been requested but not dispatched clearing the cache means we can queue the same id again.

We have changed the clear methods to re-cache the queued requests.

Have not added any tests yet.
What other changes would like to see to get this in state that you would accept.

Maybe this behavior should be configurable on the dataloader what would you consider the default setting?


Thank you.




