### PR TITLE
Generate cache key with loadContext.

### DIFF
--- a/src/main/java/org/dataloader/CacheKey.java
+++ b/src/main/java/org/dataloader/CacheKey.java
@@ -35,4 +35,8 @@ public interface CacheKey<K> {
      * @return the cache key
      */
     Object getKey(K input);
+
+    default Object getKeyWithContext(K input, Object context) {
+        return getKey(input);
+    }
 }

--- a/src/main/java/org/dataloader/CacheKey.java
+++ b/src/main/java/org/dataloader/CacheKey.java
@@ -36,6 +36,15 @@ public interface CacheKey<K> {
      */
     Object getKey(K input);
 
+    /**
+     * Returns the cache key that is created from the provided input key and context.
+     *
+     * @param input the input key
+     *
+     * @param context the context
+     *
+     * @return the cache key
+     */
     default Object getKeyWithContext(K input, Object context) {
         return getKey(input);
     }

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -104,7 +104,14 @@ class DataLoaderHelper<K, V> {
             boolean batchingEnabled = loaderOptions.batchingEnabled();
             boolean cachingEnabled = loaderOptions.cachingEnabled();
 
-            Object cacheKey = cachingEnabled ? getCacheKey(nonNull(key)) : null;
+            Object cacheKey = null;
+            if (cachingEnabled) {
+                if (loadContext == null) {
+                    cacheKey = getCacheKey(key);
+                } else {
+                    cacheKey = getCacheKeyWithContext(key, loadContext);
+                }
+            }
             stats.incrementLoadCount();
 
             if (cachingEnabled) {
@@ -133,6 +140,12 @@ class DataLoaderHelper<K, V> {
     Object getCacheKey(K key) {
         return loaderOptions.cacheKeyFunction().isPresent() ?
                 loaderOptions.cacheKeyFunction().get().getKey(key) : key;
+    }
+
+    @SuppressWarnings("unchecked")
+    Object getCacheKeyWithContext(K key, Object context) {
+        return loaderOptions.cacheKeyFunction().isPresent() ?
+                loaderOptions.cacheKeyFunction().get().getKeyWithContext(key, context): key;
     }
 
     DispatchResult<V> dispatch() {


### PR DESCRIPTION
When result depends on both key and context, i.e. `load(key, context)`, cacheKey should depend on context.