### PR TITLE
cache values and errors, not futures

### DIFF
--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -18,12 +18,10 @@ package org.dataloader;
 
 import org.dataloader.impl.DefaultCacheMap;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * Cache map interface for data loaders that use caching.
  * <p>
- * The default implementation used by the data loader is based on a {@link java.util.LinkedHashMap}. Note that the
+ * The default implementation used by the data loader is based on a {@link java.util.concurrent.ConcurrentHashMap}. Note that the
  * implementation could also have used a regular {@link java.util.Map} instead of this {@link CacheMap}, but
  * this aligns better to the reference data loader implementation provided by Facebook
  * <p>
@@ -39,19 +37,19 @@ import java.util.concurrent.CompletableFuture;
 public interface CacheMap<U, V> {
 
     /**
-     * Creates a new cache map, using the default implementation that is based on a {@link java.util.LinkedHashMap}.
+     * Creates a new cache map, using the default implementation that is based on a {@link java.util.concurrent.ConcurrentHashMap}.
      *
      * @param <U> type parameter indicating the type of the cache keys
      * @param <V> type parameter indicating the type of the data that is cached
      *
      * @return the cache map
      */
-    static <U, V> CacheMap<U, CompletableFuture<V>> simpleMap() {
+    static <U, V> CacheMap<U, V> simpleMap() {
         return new DefaultCacheMap<>();
     }
 
     /**
-     * Checks whether the specified key is contained in the cach map.
+     * Checks whether the specified key is contained in the cache map.
      *
      * @param key the key to check
      *
@@ -69,7 +67,7 @@ public interface CacheMap<U, V> {
      *
      * @return the cached value, or {@code null} if not found (depends on cache implementation)
      */
-    V get(U key);
+    Try<V> get(U key);
 
     /**
      * Creates a new cache map entry with the specified key and value, or updates the value if the key already exists.
@@ -80,6 +78,36 @@ public interface CacheMap<U, V> {
      * @return the cache map for fluent coding
      */
     CacheMap<U, V> set(U key, V value);
+
+    /**
+     * Creates a new cache entry with the specified key and error, or updates the error if the key already exists.
+     *
+     * @param key   the key to cache
+     * @param error the error to cache
+     *
+     * @return the cache map for fluent coding
+     */
+    CacheMap<U, V> set(U key, Throwable error);
+
+    /**
+     * Creates a new cache map entry with the specified key and value if it doesn't exist.
+     *
+     * @param key   the key to cache
+     * @param value the value to cache
+     *
+     * @return the cache map for fluent coding
+     */
+    CacheMap<U, V> setIfAbsent(U key, V value);
+
+    /**
+     * Creates a new cache map entry with the specified key and error if it doesn't exist.
+     *
+     * @param key   the key to cache
+     * @param error the value to cache
+     *
+     * @return the cache map for fluent coding
+     */
+    CacheMap<U, V> setIfAbsent(U key, Throwable error);
 
     /**
      * Deletes the entry with the specified key from the cache map, if it exists.

--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -23,7 +23,7 @@ import org.dataloader.impl.DefaultCacheMap;
  * <p>
  * The default implementation used by the data loader is based on a {@link java.util.concurrent.ConcurrentHashMap}. Note that the
  * implementation could also have used a regular {@link java.util.Map} instead of this {@link CacheMap}, but
- * this aligns better to the reference data loader implementation provided by Facebook
+ * this aligns better to the reference data loader implementation provided by Facebook.
  * <p>
  * Also it doesn't require you to implement the full set of map overloads, just the required methods.
  *
@@ -60,12 +60,14 @@ public interface CacheMap<U, V> {
     /**
      * Gets the specified key from the cache map.
      * <p>
+     * The result is wrapped in a {@link Try} to support caching both values and errors.
+     * <p>
      * May throw an exception if the key does not exists, depending on the cache map implementation that is used,
      * so be sure to check {@link CacheMap#containsKey(Object)} first.
      *
      * @param key the key to retrieve
      *
-     * @return the cached value, or {@code null} if not found (depends on cache implementation)
+     * @return the cached value, error, or {@code null} if not found (depends on cache implementation)
      */
     Try<V> get(U key);
 
@@ -88,26 +90,6 @@ public interface CacheMap<U, V> {
      * @return the cache map for fluent coding
      */
     CacheMap<U, V> set(U key, Throwable error);
-
-    /**
-     * Creates a new cache map entry with the specified key and value if it doesn't exist.
-     *
-     * @param key   the key to cache
-     * @param value the value to cache
-     *
-     * @return the cache map for fluent coding
-     */
-    CacheMap<U, V> setIfAbsent(U key, V value);
-
-    /**
-     * Creates a new cache map entry with the specified key and error if it doesn't exist.
-     *
-     * @param key   the key to cache
-     * @param error the value to cache
-     *
-     * @return the cache map for fluent coding
-     */
-    CacheMap<U, V> setIfAbsent(U key, Throwable error);
 
     /**
      * Deletes the entry with the specified key from the cache map, if it exists.

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -548,7 +548,9 @@ public class DataLoader<K, V> {
     public DataLoader<K, V> prime(K key, V value) {
         Object cacheKey = getCacheKey(key);
         synchronized (this) {
-            valueCache.setIfAbsent(cacheKey, value);
+            if (!valueCache.containsKey(cacheKey)) {
+                valueCache.set(cacheKey, value);
+            }
         }
         return this;
     }
@@ -563,7 +565,9 @@ public class DataLoader<K, V> {
     public DataLoader<K, V> prime(K key, Throwable error) {
         Object cacheKey = getCacheKey(key);
         synchronized (this) {
-            valueCache.setIfAbsent(cacheKey, error);
+            if (!valueCache.containsKey(cacheKey)) {
+                valueCache.set(cacheKey, error);
+            }
         }
         return this;
     }

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -79,17 +79,7 @@ class DataLoaderHelper<K, V> {
                 Object cacheKey = getCacheKey(nonNull(key));
                 if (valueCache.containsKey(cacheKey)) {
                     stats.incrementCacheHitCount();
-
-                    CompletableFuture<V> futureValue = new CompletableFuture<>();
-                    Try<V> cacheResult = valueCache.get(cacheKey);
-
-                    if (cacheResult.isFailure()) {
-                        futureValue.completeExceptionally(cacheResult.getThrowable());
-                    } else {
-                        futureValue.complete(cacheResult.get());
-                    }
-
-                    return Optional.of(futureValue);
+                    return Optional.of(CompletableFutureKit.fromTry(valueCache.get(key)));
                 }
             }
         }
@@ -128,17 +118,7 @@ class DataLoaderHelper<K, V> {
             if (cachingEnabled) {
                 if (valueCache.containsKey(cacheKey.get())) {
                     stats.incrementCacheHitCount();
-
-                    CompletableFuture<V> futureValue = new CompletableFuture<>();
-                    Try<V> cacheResult = valueCache.get(cacheKey.get());
-
-                    if (cacheResult.isFailure()) {
-                        futureValue.completeExceptionally(cacheResult.getThrowable());
-                    } else {
-                        futureValue.complete(cacheResult.get());
-                    }
-
-                    return futureValue;
+                    return CompletableFutureKit.fromTry(valueCache.get(cacheKey.get()));
                 }
             }
 

--- a/src/main/java/org/dataloader/impl/CompletableFutureKit.java
+++ b/src/main/java/org/dataloader/impl/CompletableFutureKit.java
@@ -5,6 +5,7 @@ import org.dataloader.Internal;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.dataloader.Try;
 
 import static java.util.stream.Collectors.toList;
 
@@ -14,7 +15,7 @@ import static java.util.stream.Collectors.toList;
 @Internal
 public class CompletableFutureKit {
 
-    public static <V> CompletableFuture<V> failedFuture(Exception e) {
+    public static <V> CompletableFuture<V> failedFuture(Throwable e) {
         CompletableFuture<V> future = new CompletableFuture<>();
         future.completeExceptionally(e);
         return future;
@@ -53,5 +54,13 @@ public class CompletableFutureKit {
                         .map(CompletableFuture::join)
                         .collect(toList())
                 );
+    }
+
+    public static <T> CompletableFuture<T> fromTry(Try<T> tryResult) {
+        if (tryResult.isFailure()) {
+            return failedFuture(tryResult.getThrowable());
+        } else {
+            return CompletableFuture.completedFuture(tryResult.get());
+        }
     }
 }

--- a/src/main/java/org/dataloader/impl/DefaultCacheMap.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheMap.java
@@ -91,26 +91,6 @@ public class DefaultCacheMap<U, V> implements CacheMap<U, V> {
      * {@inheritDoc}
      */
     @Override
-    public CacheMap<U, V> setIfAbsent(U key, V value) {
-        cache.putIfAbsent(key, value);
-        errorCache.remove(key);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public CacheMap<U, V> setIfAbsent(U key, Throwable error) {
-        cache.remove(key);
-        errorCache.putIfAbsent(key, error);
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public CacheMap<U, V> delete(U key) {
         cache.remove(key);
         errorCache.remove(key);

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -213,12 +213,27 @@ public class ReadmeExamples {
         }
 
         @Override
-        public Object get(Object key) {
+        public Try get(Object key) {
             return null;
         }
 
         @Override
         public CacheMap set(Object key, Object value) {
+            return null;
+        }
+
+        @Override
+        public CacheMap set(Object key, Throwable error) {
+            return null;
+        }
+
+        @Override
+        public CacheMap setIfAbsent(Object key, Object value) {
+            return null;
+        }
+
+        @Override
+        public CacheMap setIfAbsent(Object key, Throwable error) {
             return null;
         }
 

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -228,16 +228,6 @@ public class ReadmeExamples {
         }
 
         @Override
-        public CacheMap setIfAbsent(Object key, Object value) {
-            return null;
-        }
-
-        @Override
-        public CacheMap setIfAbsent(Object key, Throwable error) {
-            return null;
-        }
-
-        @Override
         public CacheMap delete(Object key) {
             return null;
         }

--- a/src/test/java/org/dataloader/CustomCacheMap.java
+++ b/src/test/java/org/dataloader/CustomCacheMap.java
@@ -17,13 +17,31 @@ public class CustomCacheMap implements CacheMap<String, Object> {
     }
 
     @Override
-    public Object get(String key) {
-        return stash.get(key);
+    public Try<Object> get(String key) {
+        return Try.succeeded(stash.get(key));
     }
 
     @Override
     public CacheMap<String, Object> set(String key, Object value) {
         stash.put(key, value);
+        return this;
+    }
+
+    @Override
+    public CacheMap<String, Object> set(String key, Throwable error) {
+        // Don't cache errors in this implementation
+        return this;
+    }
+
+    @Override
+    public CacheMap<String, Object> setIfAbsent(String key, Object value) {
+        stash.putIfAbsent(key, value);
+        return this;
+    }
+
+    @Override
+    public CacheMap<String, Object> setIfAbsent(String key, Throwable error) {
+        // Don't cache errors in this implementation
         return this;
     }
 

--- a/src/test/java/org/dataloader/CustomCacheMap.java
+++ b/src/test/java/org/dataloader/CustomCacheMap.java
@@ -34,18 +34,6 @@ public class CustomCacheMap implements CacheMap<String, Object> {
     }
 
     @Override
-    public CacheMap<String, Object> setIfAbsent(String key, Object value) {
-        stash.putIfAbsent(key, value);
-        return this;
-    }
-
-    @Override
-    public CacheMap<String, Object> setIfAbsent(String key, Throwable error) {
-        // Don't cache errors in this implementation
-        return this;
-    }
-
-    @Override
     public CacheMap<String, Object> delete(String key) {
         stash.remove(key);
         return this;


### PR DESCRIPTION
I believe this fixes #59 by explicitly caching values, not completed futures, and it implicitly fixes #45 because the signature becomes correct with this change. 

I don't think there is a way to do this in a non-breaking fashion, but I still think it's worth doing for the next release. Since I'm in here breaking things, one question I have is why do we use `Object` everywhere for the cache key. Can we instead change the signature of `CacheMap<K, V>` to be `CacheMap<V>` and then have the functions look like `get(CacheKey key)` and `set(CacheKey key, V value)`? 

On the breaking note, I changed the error state to use `Throwable` because it's more common and generic. It also plays nicer with converting to/from `CompletableFuture`. 

I also switched the default implementation to use a `ConcurrentHashMap` which can help avoid some `synchronized` calls and eliminate the chance of colliding cache operations. ~In addition, I added a quality-of-life function, `computeIfAbsent`, but I'm happy to remove that from this PR if we think it's out of scope.~