### PR TITLE
future cache vs value cache

### DIFF
--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -51,7 +51,7 @@ public interface CacheMap<U, V> {
     }
 
     /**
-     * Checks whether the specified key is contained in the cach map.
+     * Checks whether the specified key is contained in the cache map.
      *
      * @param key the key to check
      *
@@ -91,7 +91,7 @@ public interface CacheMap<U, V> {
     CacheMap<U, V> delete(U key);
 
     /**
-     * Clears all entries of the cache map
+     * Clears all entries of the cache map.
      *
      * @return the cache map for fluent coding
      */

--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -46,7 +46,7 @@ public interface CacheMap<U, V> {
      *
      * @return the cache map
      */
-    static <U, V> CacheMap<U, CompletableFuture<V>> simpleMap() {
+    static <U, V> CacheMap<U, V> simpleMap() {
         return new DefaultCacheMap<>();
     }
 
@@ -69,7 +69,7 @@ public interface CacheMap<U, V> {
      *
      * @return the cached value, or {@code null} if not found (depends on cache implementation)
      */
-    V get(U key);
+    CompletableFuture<V> get(U key);
 
     /**
      * Creates a new cache map entry with the specified key and value, or updates the value if the key already exists.
@@ -79,7 +79,7 @@ public interface CacheMap<U, V> {
      *
      * @return the cache map for fluent coding
      */
-    CacheMap<U, V> set(U key, V value);
+    CacheMap<U, V> set(U key, CompletableFuture<V> value);
 
     /**
      * Deletes the entry with the specified key from the cache map, if it exists.

--- a/src/main/java/org/dataloader/CacheStore.java
+++ b/src/main/java/org/dataloader/CacheStore.java
@@ -1,0 +1,21 @@
+package org.dataloader;
+
+import java.util.concurrent.CompletableFuture;
+import org.dataloader.impl.DefaultCacheStore;
+
+public interface CacheStore<K, V> {
+
+  static <K, V> CacheStore<K, V> defaultStore() {
+    return new DefaultCacheStore<>();
+  }
+
+  CompletableFuture<Boolean> has(K key);
+
+  CompletableFuture<V> get(K key);
+
+  CompletableFuture<V> set(K key, V value);
+
+  CompletableFuture<Void> delete(K key);
+
+  CompletableFuture<Void> clear();
+}

--- a/src/main/java/org/dataloader/CacheStore.java
+++ b/src/main/java/org/dataloader/CacheStore.java
@@ -1,21 +1,80 @@
 package org.dataloader;
 
-import java.util.concurrent.CompletableFuture;
 import org.dataloader.impl.DefaultCacheStore;
 
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Remote cache store for data loaders that use caching and want a long-lived or external cache.
+ * <p>
+ * The default implementation is a no-op store which replies with the key always missing and doesn't
+ * store any actual results. This is to avoid duplicating the stored data between the {@link CacheMap}
+ * and the store.
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ *
+ * @author <a href="https://github.com/craig-day">Craig Day</a>
+ */
+@PublicSpi
 public interface CacheStore<K, V> {
 
+  /**
+   * Creates a new store, using the default no-op implementation.
+   *
+   * @param <K> the type of cache keys
+   * @param <V> the type of cache values
+   *
+   * @return the cache store
+   */
   static <K, V> CacheStore<K, V> defaultStore() {
     return new DefaultCacheStore<>();
   }
 
+  /**
+   * Checks whether the specified key is contained in the store.
+   *
+   * @param key the key to check
+   *
+   * @return {@code true} if the cache contains the key, {@code false} otherwise
+   */
   CompletableFuture<Boolean> has(K key);
 
+  /**
+   * Gets the specified key from the store.
+   *
+   * @apiNote The future may fail if the key does not exist depending on implementation. It is
+   * recommended to compose this call with {@link #has(Object)}.
+   *
+   * @param key the key to retrieve
+   *
+   * @return a future containing the cached value, or {@code null} if not found (depends on implementation)
+   */
   CompletableFuture<V> get(K key);
 
+  /**
+   * Stores the value with the specified key, or updates it if the key already exists.
+   *
+   * @param key   the key to store
+   * @param value the value to store
+   *
+   * @return a future containing the stored value for fluent composition
+   */
   CompletableFuture<V> set(K key, V value);
 
+  /**
+   * Deletes the entry with the specified key from the store, if it exists.
+   *
+   * @param key the key to delete
+   *
+   * @return a void future for error handling and fluent composition
+   */
   CompletableFuture<Void> delete(K key);
 
+  /**
+   * Clears all entries from the store.
+   *
+   * @return a void future for error handling and fluent composition
+   */
   CompletableFuture<Void> clear();
 }

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -39,6 +39,7 @@ public class DataLoaderOptions {
     private boolean cachingExceptionsEnabled;
     private CacheKey cacheKeyFunction;
     private CacheMap cacheMap;
+    private CacheStore cacheStore;
     private int maxBatchSize;
     private Supplier<StatisticsCollector> statisticsCollector;
     private BatchLoaderContextProvider environmentProvider;
@@ -67,6 +68,7 @@ public class DataLoaderOptions {
         this.cachingExceptionsEnabled = other.cachingExceptionsEnabled;
         this.cacheKeyFunction = other.cacheKeyFunction;
         this.cacheMap = other.cacheMap;
+        this.cacheStore = other.cacheStore;
         this.maxBatchSize = other.maxBatchSize;
         this.statisticsCollector = other.statisticsCollector;
         this.environmentProvider = other.environmentProvider;
@@ -190,6 +192,15 @@ public class DataLoaderOptions {
      */
     public DataLoaderOptions setCacheMap(CacheMap cacheMap) {
         this.cacheMap = cacheMap;
+        return this;
+    }
+
+    public Optional<CacheStore> cacheStore() {
+        return Optional.ofNullable(cacheStore);
+    }
+
+    public DataLoaderOptions setCacheStore(CacheStore cacheStore) {
+        this.cacheStore = cacheStore;
         return this;
     }
 

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -39,7 +39,7 @@ public class DataLoaderOptions {
     private boolean cachingExceptionsEnabled;
     private CacheKey cacheKeyFunction;
     private CacheMap cacheMap;
-    private CacheStore cacheStore;
+    private CacheStore remoteValueStore;
     private int maxBatchSize;
     private Supplier<StatisticsCollector> statisticsCollector;
     private BatchLoaderContextProvider environmentProvider;
@@ -68,7 +68,7 @@ public class DataLoaderOptions {
         this.cachingExceptionsEnabled = other.cachingExceptionsEnabled;
         this.cacheKeyFunction = other.cacheKeyFunction;
         this.cacheMap = other.cacheMap;
-        this.cacheStore = other.cacheStore;
+        this.remoteValueStore = other.remoteValueStore;
         this.maxBatchSize = other.maxBatchSize;
         this.statisticsCollector = other.statisticsCollector;
         this.environmentProvider = other.environmentProvider;
@@ -195,12 +195,26 @@ public class DataLoaderOptions {
         return this;
     }
 
-    public Optional<CacheStore> cacheStore() {
-        return Optional.ofNullable(cacheStore);
+    /**
+     * Gets the (optional) cache store implementation that is used for value storage, if caching is enabled.
+     * <p>
+     * If missing, a no-op implementation will be used.
+     *
+     * @return an optional with the cache store instance, or empty
+     */
+    public Optional<CacheStore> remoteValueStore() {
+        return Optional.ofNullable(remoteValueStore);
     }
 
-    public DataLoaderOptions setCacheStore(CacheStore cacheStore) {
-        this.cacheStore = cacheStore;
+    /**
+     * Sets the value store implementation to use for caching values, if caching is enabled.
+     *
+     * @param remoteValueStore the cache store instance
+     *
+     * @return the data loader options for fluent coding
+     */
+    public DataLoaderOptions setRemoteValueStore(CacheStore remoteValueStore) {
+        this.remoteValueStore = remoteValueStore;
         return this;
     }
 

--- a/src/main/java/org/dataloader/impl/DefaultCacheMap.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheMap.java
@@ -16,6 +16,7 @@
 
 package org.dataloader.impl;
 
+import java.util.concurrent.CompletableFuture;
 import org.dataloader.CacheMap;
 import org.dataloader.Internal;
 
@@ -33,7 +34,7 @@ import java.util.Map;
 @Internal
 public class DefaultCacheMap<U, V> implements CacheMap<U, V> {
 
-    private final Map<U, V> cache;
+    private final Map<U, CompletableFuture<V>> cache;
 
     /**
      * Default constructor
@@ -54,7 +55,7 @@ public class DefaultCacheMap<U, V> implements CacheMap<U, V> {
      * {@inheritDoc}
      */
     @Override
-    public V get(U key) {
+    public CompletableFuture<V> get(U key) {
         return cache.get(key);
     }
 
@@ -62,7 +63,7 @@ public class DefaultCacheMap<U, V> implements CacheMap<U, V> {
      * {@inheritDoc}
      */
     @Override
-    public CacheMap<U, V> set(U key, V value) {
+    public CacheMap<U, V> set(U key, CompletableFuture<V> value) {
         cache.put(key, value);
         return this;
     }

--- a/src/main/java/org/dataloader/impl/DefaultCacheStore.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheStore.java
@@ -1,40 +1,61 @@
 package org.dataloader.impl;
 
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import org.dataloader.CacheStore;
 import org.dataloader.Internal;
 
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default implementation of {@link CacheStore} that does nothing.
+ * <p>
+ * We don't want to store values in memory twice, so when using the default store we just
+ * say we never have the key and complete the other methods by doing nothing.
+ *
+ * @param <K> the type of cache keys
+ * @param <V> the type of cache values
+ *
+ * @author <a href="https://github.com/craig-day">Craig Day</a>
+ */
 @Internal
 public class DefaultCacheStore<K, V> implements CacheStore<K, V> {
 
-  private final Map<K, V> store = new ConcurrentHashMap<>();
-
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public CompletableFuture<Boolean> has(K key) {
-    return CompletableFuture.completedFuture(store.containsKey(key));
+    return CompletableFuture.completedFuture(false);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public CompletableFuture<V> get(K key) {
-    return CompletableFuture.completedFuture(store.get(key));
+    return CompletableFutureKit.failedFuture(new UnsupportedOperationException());
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public CompletableFuture<V> set(K key, V value) {
-    return CompletableFuture.completedFuture(store.put(key, value));
+    return CompletableFuture.completedFuture(value);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public CompletableFuture<Void> delete(K key) {
-    store.remove(key);
     return CompletableFuture.completedFuture(null);
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public CompletableFuture<Void> clear() {
-    store.clear();
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/src/main/java/org/dataloader/impl/DefaultCacheStore.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheStore.java
@@ -1,0 +1,40 @@
+package org.dataloader.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.dataloader.CacheStore;
+import org.dataloader.Internal;
+
+@Internal
+public class DefaultCacheStore<K, V> implements CacheStore<K, V> {
+
+  private final Map<K, V> store = new ConcurrentHashMap<>();
+
+  @Override
+  public CompletableFuture<Boolean> has(K key) {
+    return CompletableFuture.completedFuture(store.containsKey(key));
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key) {
+    return CompletableFuture.completedFuture(store.get(key));
+  }
+
+  @Override
+  public CompletableFuture<V> set(K key, V value) {
+    return CompletableFuture.completedFuture(store.put(key, value));
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(K key) {
+    store.remove(key);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> clear() {
+    store.clear();
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -213,12 +213,12 @@ public class ReadmeExamples {
         }
 
         @Override
-        public Object get(Object key) {
+        public CompletableFuture get(Object key) {
             return null;
         }
 
         @Override
-        public CacheMap set(Object key, Object value) {
+        public CacheMap set(Object key, CompletableFuture value) {
             return null;
         }
 

--- a/src/test/java/org/dataloader/CustomCacheMap.java
+++ b/src/test/java/org/dataloader/CustomCacheMap.java
@@ -2,10 +2,11 @@ package org.dataloader;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class CustomCacheMap implements CacheMap<String, Object> {
 
-    public Map<String, Object> stash;
+    public Map<String, CompletableFuture<Object>> stash;
 
     public CustomCacheMap() {
         stash = new LinkedHashMap<>();
@@ -17,12 +18,12 @@ public class CustomCacheMap implements CacheMap<String, Object> {
     }
 
     @Override
-    public Object get(String key) {
+    public CompletableFuture<Object> get(String key) {
         return stash.get(key);
     }
 
     @Override
-    public CacheMap<String, Object> set(String key, Object value) {
+    public CacheMap<String, Object> set(String key, CompletableFuture<Object> value) {
         stash.put(key, value);
         return this;
     }

--- a/src/test/java/org/dataloader/CustomCacheStore.java
+++ b/src/test/java/org/dataloader/CustomCacheStore.java
@@ -1,0 +1,38 @@
+package org.dataloader;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CustomCacheStore implements CacheStore<String, Object> {
+
+  public final Map<String, Object> store = new ConcurrentHashMap<>();
+
+  @Override
+  public CompletableFuture<Boolean> has(String key) {
+    return CompletableFuture.completedFuture(store.containsKey(key));
+  }
+
+  @Override
+  public CompletableFuture<Object> get(String key) {
+    return CompletableFuture.completedFuture(store.get(key));
+  }
+
+  @Override
+  public CompletableFuture<Object> set(String key, Object value) {
+    store.put(key, value);
+    return CompletableFuture.completedFuture(value);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(String key) {
+    store.remove(key);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> clear() {
+    store.clear();
+    return CompletableFuture.completedFuture(null);
+  }
+}


### PR DESCRIPTION
This fixes #45 by updating the `CacheMap` signature to reflect how it is really used. This also resolves #59 by introducing a new concept, the `CacheStore`. 

The `CacheMap` stores futures/promises for results, so it can be synchronous and prevents us from queueing multiple `load` calls. It isn't straightforward to adjust this to just store values, because we can't store a value in the cache until the load has completed, so we would end up issuing every load during a request instead of re-using a load. 

My proposed solution is to add a second layer of caching. The first layer of cache, L1, still stores the `CompletableFuture` that will eventually contain the result, so we don't issue multiple `load` calls. The new layer, L2, is where the `CacheStore` comes in. The general algorithm works something like this:

```text
if L1 contains key
  return value from L1

else
  result = new promise for data

  if L2 contains key
    promiseFromL2 = get key from L2
    when promiseFromL2 is complete, complete result

  else
    promiseFromLoad = issue load request
    when promiseFromLoad is complete, store result in cache
    when cache store is complete, complete result

  store result in L1

  return result
```