### PR TITLE
Add synchronized to loaderQueue inside completable future

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -311,8 +311,10 @@ class DataLoaderHelper<K, V> {
             if (getCallEx == null) {
                 future.complete(cachedValue);
             } else {
-                queueOrInvokeLoader(key, loadContext, batchingEnabled)
-                        .whenComplete(setValueIntoCacheAndCompleteFuture(cacheKey, future));
+                synchronized (dataLoader) {
+                    queueOrInvokeLoader(key, loadContext, batchingEnabled)
+                            .whenComplete(setValueIntoCacheAndCompleteFuture(cacheKey, future));
+                }
             }
         });
 


### PR DESCRIPTION

**Describe the bug**
A bug that may cause jobs not to be added to `loaderQueue` due to race conditions.
`DataLoader.load(K key, Object loadContext)`  has two ways of getting value, first - get immediately or add to queue, second - retrieve from the cache. Retrieving from cache works through consecutive CompletableFuture calls, if the cache misses then we add to queue or load immediately. The first way covered by synchronized on `dataLoader` but the second isn't.

This PR fixes this issue by adding synchronized on callback if the cache misses

**To Reproduce**
It's hard to reproduce because of multithreading
