### PR TITLE
ValueCache calls are made inside the batch load call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,19 @@ version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 group = 'com.graphql-java'
 description = 'A pure Java 8 port of Facebook Dataloader'
 
+gradle.buildFinished { buildResult ->
+    println "*******************************"
+    println "*"
+    if (buildResult.failure != null) {
+        println "* FAILURE - ${buildResult.failure}"
+    } else {
+        println "* SUCCESS"
+    }
+    println "* Version: $version"
+    println "*"
+    println "*******************************"
+}
+
 repositories {
     mavenCentral()
     mavenLocal()

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -67,7 +67,7 @@ public class DataLoader<K, V> {
     private final DataLoaderHelper<K, V> helper;
     private final StatisticsCollector stats;
     private final CacheMap<Object, V> futureCache;
-    private final ValueCache<Object, V> valueCache;
+    private final ValueCache<K, V> valueCache;
 
     /**
      * Creates new DataLoader with the specified batch loader function and default options
@@ -430,8 +430,8 @@ public class DataLoader<K, V> {
     }
 
     @SuppressWarnings("unchecked")
-    private ValueCache<Object, V> determineValueCache(DataLoaderOptions loaderOptions) {
-        return (ValueCache<Object, V>) loaderOptions.valueCache().orElseGet(ValueCache::defaultValueCache);
+    private ValueCache<K, V> determineValueCache(DataLoaderOptions loaderOptions) {
+        return (ValueCache<K, V>) loaderOptions.valueCache().orElseGet(ValueCache::defaultValueCache);
     }
 
     /**

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -17,6 +17,7 @@
 package org.dataloader;
 
 import org.dataloader.annotations.PublicApi;
+import org.dataloader.impl.Assertions;
 import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.StatisticsCollector;
 
@@ -39,11 +40,12 @@ public class DataLoaderOptions {
     private boolean cachingEnabled;
     private boolean cachingExceptionsEnabled;
     private CacheKey<?> cacheKeyFunction;
-    private CacheMap<?,?> cacheMap;
-    private ValueCache<?,?> valueCache;
+    private CacheMap<?, ?> cacheMap;
+    private ValueCache<?, ?> valueCache;
     private int maxBatchSize;
     private Supplier<StatisticsCollector> statisticsCollector;
     private BatchLoaderContextProvider environmentProvider;
+    private ValueCacheOptions valueCacheOptions;
 
     /**
      * Creates a new data loader options with default settings.
@@ -55,6 +57,7 @@ public class DataLoaderOptions {
         maxBatchSize = -1;
         statisticsCollector = SimpleStatisticsCollector::new;
         environmentProvider = NULL_PROVIDER;
+        valueCacheOptions = ValueCacheOptions.newOptions();
     }
 
     /**
@@ -72,6 +75,7 @@ public class DataLoaderOptions {
         this.maxBatchSize = other.maxBatchSize;
         this.statisticsCollector = other.statisticsCollector;
         this.environmentProvider = other.environmentProvider;
+        this.valueCacheOptions = other.valueCacheOptions;
     }
 
     /**
@@ -179,7 +183,7 @@ public class DataLoaderOptions {
      *
      * @return an optional with the cache map instance, or empty
      */
-    public Optional<CacheMap<?,?>> cacheMap() {
+    public Optional<CacheMap<?, ?>> cacheMap() {
         return Optional.ofNullable(cacheMap);
     }
 
@@ -190,7 +194,7 @@ public class DataLoaderOptions {
      *
      * @return the data loader options for fluent coding
      */
-    public DataLoaderOptions setCacheMap(CacheMap<?,?> cacheMap) {
+    public DataLoaderOptions setCacheMap(CacheMap<?, ?> cacheMap) {
         this.cacheMap = cacheMap;
         return this;
     }
@@ -265,7 +269,7 @@ public class DataLoaderOptions {
      *
      * @return an optional with the cache store instance, or empty
      */
-    public Optional<ValueCache<?,?>> valueCache() {
+    public Optional<ValueCache<?, ?>> valueCache() {
         return Optional.ofNullable(valueCache);
     }
 
@@ -276,8 +280,27 @@ public class DataLoaderOptions {
      *
      * @return the data loader options for fluent coding
      */
-    public DataLoaderOptions setValueCache(ValueCache<?,?> valueCache) {
+    public DataLoaderOptions setValueCache(ValueCache<?, ?> valueCache) {
         this.valueCache = valueCache;
+        return this;
+    }
+
+    /**
+     * @return the {@link ValueCacheOptions} that control how the {@link ValueCache} will be used
+     */
+    public ValueCacheOptions getValueCacheOptions() {
+        return valueCacheOptions;
+    }
+
+    /**
+     * Sets the {@link ValueCacheOptions} that control how the {@link ValueCache} will be used
+     *
+     * @param valueCacheOptions the value cache options
+     *
+     * @return the data loader options for fluent coding
+     */
+    public DataLoaderOptions setValueCacheOptions(ValueCacheOptions valueCacheOptions) {
+        this.valueCacheOptions = Assertions.nonNull(valueCacheOptions);
         return this;
     }
 }

--- a/src/main/java/org/dataloader/ValueCache.java
+++ b/src/main/java/org/dataloader/ValueCache.java
@@ -7,14 +7,17 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * The {@link ValueCache} is used by data loaders that use caching and want a long-lived or external cache
- * of values.  The {@link ValueCache} is used as a place to cache values when they come back from
+ * of values.  The {@link ValueCache} is used as a place to cache values when they come back from an async
+ * cache store.
  * <p>
- * It differs from {@link CacheMap} which is in fact a cache of promises to values aka {@link CompletableFuture}&lt;V&gt; and it rather suited
- * to be a wrapper of a long lived or external value cache.  {@link CompletableFuture}s cant be easily placed in an external cache
- * outside the JVM say, hence the need for the {@link ValueCache}.
+ * It differs from {@link CacheMap} which is in fact a cache of promised values aka {@link CompletableFuture}&lt;V&gt;'s.
+ * <p>
+ * {@link ValueCache is more suited to be a wrapper of a long-lived or externallly cached values.  {@link CompletableFuture}s cant
+ * be easily placed in an external cache outside the JVM say, hence the need for the {@link ValueCache}.
  * <p>
  * {@link DataLoader}s use a two stage cache strategy if caching is enabled.  If the {@link CacheMap} already has the promise to a value
  * that is used.  If not then the {@link ValueCache} is asked for a value, if it has one then that is returned (and cached as a promise in the {@link CacheMap}.
+ * <p>
  * If there is no value then the key is queued and loaded via the {@link BatchLoader} calls.  The returned values will then be stored in
  * the {@link ValueCache} and the promises to those values are also stored in the {@link CacheMap}.
  * <p>
@@ -22,17 +25,17 @@ import java.util.concurrent.CompletableFuture;
  * store any actual results. This is to avoid duplicating the stored data between the {@link CacheMap}
  * out of the box.
  * <p>
- * The API signature uses completable futures because the backing implementation MAY be a remote external cache
- * and hence exceptions may happen in retrieving values.
+ * The API signature uses {@link CompletableFuture}s because the backing implementation MAY be a remote external cache
+ * and hence exceptions may happen in retrieving values and they may take time to complete.
  *
  * @param <K> the type of cache keys
  * @param <V> the type of cache values
  *
  * @author <a href="https://github.com/craig-day">Craig Day</a>
+ * @author <a href="https://github.com/bbakerman/">Brad Baker</a>
  */
 @PublicSpi
 public interface ValueCache<K, V> {
-
 
     /**
      * Creates a new value cache, using the default no-op implementation.
@@ -48,9 +51,12 @@ public interface ValueCache<K, V> {
     }
 
     /**
-     * Gets the specified key from the store.  if the key si not present, then the implementation MUST return an exceptionally completed future
-     * and not null because null is a valid cacheable value.  Any exception is will cause {@link DataLoader} to load the key via batch loading
+     * Gets the specified key from the value cache.  If the key is not present, then the implementation MUST return an exceptionally completed future
+     * and not null because null is a valid cacheable value.  An exceptionally completed future will cause {@link DataLoader} to load the key via batch loading
      * instead.
+     * <p>
+     * NOTE: Your implementation MUST not throw exceptions, rather it should return a CompletableFuture that has completed exceptionally.  Failure
+     * to do this may cause the {@link DataLoader} code to not run properly.
      *
      * @param key the key to retrieve
      *
@@ -61,6 +67,9 @@ public interface ValueCache<K, V> {
 
     /**
      * Stores the value with the specified key, or updates it if the key already exists.
+     * <p>
+     * NOTE: Your implementation MUST not throw exceptions, rather it should return a CompletableFuture that has completed exceptionally.  Failure
+     * to do this may cause the {@link DataLoader} code to not run properly.
      *
      * @param key   the key to store
      * @param value the value to store
@@ -70,7 +79,10 @@ public interface ValueCache<K, V> {
     CompletableFuture<V> set(K key, V value);
 
     /**
-     * Deletes the entry with the specified key from the store, if it exists.
+     * Deletes the entry with the specified key from the value cache, if it exists.
+     * <p>
+     * NOTE: Your implementation MUST not throw exceptions, rather it should return a CompletableFuture that has completed exceptionally.  Failure
+     * to do this may cause the {@link DataLoader} code to not run properly.
      *
      * @param key the key to delete
      *
@@ -79,7 +91,10 @@ public interface ValueCache<K, V> {
     CompletableFuture<Void> delete(K key);
 
     /**
-     * Clears all entries from the store.
+     * Clears all entries from the value cache.
+     * <p>
+     * NOTE: Your implementation MUST not throw exceptions, rather it should return a CompletableFuture that has completed exceptionally.  Failure
+     * to do this may cause the {@link DataLoader} code to not run properly.
      *
      * @return a void future for error handling and fluent composition
      */

--- a/src/main/java/org/dataloader/ValueCache.java
+++ b/src/main/java/org/dataloader/ValueCache.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
  * <p>
  * It differs from {@link CacheMap} which is in fact a cache of promised values aka {@link CompletableFuture}&lt;V&gt;'s.
  * <p>
- * {@link ValueCache is more suited to be a wrapper of a long-lived or externallly cached values.  {@link CompletableFuture}s cant
+ * {@link ValueCache} is more suited to be a wrapper of a long-lived or externallly cached values.  {@link CompletableFuture}s cant
  * be easily placed in an external cache outside the JVM say, hence the need for the {@link ValueCache}.
  * <p>
  * {@link DataLoader}s use a two stage cache strategy if caching is enabled.  If the {@link CacheMap} already has the promise to a value

--- a/src/main/java/org/dataloader/ValueCache.java
+++ b/src/main/java/org/dataloader/ValueCache.java
@@ -67,34 +67,22 @@ public interface ValueCache<K, V> {
     CompletableFuture<V> get(K key);
 
     /**
-     * Gets the specified key from the value cache.  If the key is not present, then the returned {@link Try} will be a failed one
-     * other wise it has the cached value.  This is preferred over the {@link #get(Object)} method.
-     * <p>
-     *
-     * @param key the key to retrieve
-     *
-     * @return a future containing the {@link Try} cached value (which maybe null) or a failed {@link Try} if the key does
-     * not exist in the cache.
-     */
-    default CompletableFuture<Try<V>> getValue(K key) {
-        return Try.tryFuture(get(key));
-    }
-
-    /**
      * Gets the specified keys from the value cache, in a batch call.  If your underlying cache cant do batch caching retrieval
-     * then do not implement this method and it will delegate back to {@link #getValue(Object)} for you
+     * then do not implement this method and it will delegate back to {@link #get(Object)} for you
+     * <p>
+     * Each item in the returned list of values is a {@link Try}.  If the key could not be found then a failed Try just be returned otherwise
+     * a successful Try contain the cached value is returned.
      * <p>
      * You MUST return a List that is the same size as the keys passed in.  The code will assert if you do not.
      *
      * @param keys the list of keys to get cached values for.
      *
-     * @return a future containing a list of {@link Try} cached values (which maybe {@link Try#succeeded(Object)} or a failed {@link Try}
-     * per key if they do not exist in the cache.
+     * @return a future containing a list of {@link Try} cached values for each key passed in.
      */
     default CompletableFuture<List<Try<V>>> getValues(List<K> keys) {
         List<CompletableFuture<Try<V>>> cacheLookups = new ArrayList<>();
         for (K key : keys) {
-            CompletableFuture<Try<V>> cacheTry = getValue(key);
+            CompletableFuture<Try<V>> cacheTry = Try.tryFuture(get(key));
             cacheLookups.add(cacheTry);
         }
         return CompletableFutureKit.allOf(cacheLookups);

--- a/src/main/java/org/dataloader/ValueCacheOptions.java
+++ b/src/main/java/org/dataloader/ValueCacheOptions.java
@@ -1,0 +1,62 @@
+package org.dataloader;
+
+/**
+ * Options that control how the {@link ValueCache} is used by {@link DataLoader}
+ *
+ * @author <a href="https://github.com/bbakerman/">Brad Baker</a>
+ */
+public class ValueCacheOptions {
+    private final boolean dispatchOnCacheMiss;
+    private final boolean completeValueAfterCacheSet;
+
+    private ValueCacheOptions() {
+        this.dispatchOnCacheMiss = true;
+        this.completeValueAfterCacheSet = false;
+    }
+
+    private ValueCacheOptions(boolean dispatchOnCacheMiss, boolean completeValueAfterCacheSet) {
+        this.dispatchOnCacheMiss = dispatchOnCacheMiss;
+        this.completeValueAfterCacheSet = completeValueAfterCacheSet;
+    }
+
+    public static ValueCacheOptions newOptions() {
+        return new ValueCacheOptions();
+    }
+
+    /**
+     * This controls whether the {@link DataLoader} will called {@link DataLoader#dispatch()} if a
+     * {@link ValueCache#get(Object)} call misses.  In an async world this could take non zero time
+     * to complete and hence previous dispatch calls may have already completed.
+     *
+     * This is true by default.
+     *
+     * @return true if a {@link DataLoader#dispatch()} call will be made on an async {@link ValueCache} miss
+     */
+    public boolean isDispatchOnCacheMiss() {
+        return dispatchOnCacheMiss;
+    }
+
+    /**
+     * This controls whether the {@link DataLoader} will wait for the {@link ValueCache#set(Object, Object)} call
+     * to complete before it completes the returned value.  By default this is false and hence
+     * the {@link ValueCache#set(Object, Object)} call may complete some time AFTER the data loader
+     * value has been returned.
+     *
+     * This is false by default, for performance reasons.
+     *
+     * @return true the {@link DataLoader} will wait for the {@link ValueCache#set(Object, Object)} call to complete before
+     * it completes the returned value.
+     */
+    public boolean isCompleteValueAfterCacheSet() {
+        return completeValueAfterCacheSet;
+    }
+
+    public ValueCacheOptions setDispatchOnCacheMiss(boolean flag) {
+        return new ValueCacheOptions(flag, this.completeValueAfterCacheSet);
+    }
+
+    public ValueCacheOptions setCompleteValueAfterCacheSet(boolean flag) {
+        return new ValueCacheOptions(this.dispatchOnCacheMiss, flag);
+    }
+
+}

--- a/src/main/java/org/dataloader/ValueCacheOptions.java
+++ b/src/main/java/org/dataloader/ValueCacheOptions.java
@@ -6,34 +6,18 @@ package org.dataloader;
  * @author <a href="https://github.com/bbakerman/">Brad Baker</a>
  */
 public class ValueCacheOptions {
-    private final boolean dispatchOnCacheMiss;
     private final boolean completeValueAfterCacheSet;
 
     private ValueCacheOptions() {
-        this.dispatchOnCacheMiss = true;
         this.completeValueAfterCacheSet = false;
     }
 
-    private ValueCacheOptions(boolean dispatchOnCacheMiss, boolean completeValueAfterCacheSet) {
-        this.dispatchOnCacheMiss = dispatchOnCacheMiss;
+    private ValueCacheOptions(boolean completeValueAfterCacheSet) {
         this.completeValueAfterCacheSet = completeValueAfterCacheSet;
     }
 
     public static ValueCacheOptions newOptions() {
         return new ValueCacheOptions();
-    }
-
-    /**
-     * This controls whether the {@link DataLoader} will called {@link DataLoader#dispatch()} if a
-     * {@link ValueCache#get(Object)} call misses.  In an async world this could take non zero time
-     * to complete and hence previous dispatch calls may have already completed.
-     *
-     * This is true by default.
-     *
-     * @return true if a {@link DataLoader#dispatch()} call will be made on an async {@link ValueCache} miss
-     */
-    public boolean isDispatchOnCacheMiss() {
-        return dispatchOnCacheMiss;
     }
 
     /**
@@ -51,12 +35,8 @@ public class ValueCacheOptions {
         return completeValueAfterCacheSet;
     }
 
-    public ValueCacheOptions setDispatchOnCacheMiss(boolean flag) {
-        return new ValueCacheOptions(flag, this.completeValueAfterCacheSet);
-    }
-
     public ValueCacheOptions setCompleteValueAfterCacheSet(boolean flag) {
-        return new ValueCacheOptions(this.dispatchOnCacheMiss, flag);
+        return new ValueCacheOptions(flag);
     }
 
 }

--- a/src/main/java/org/dataloader/impl/Assertions.java
+++ b/src/main/java/org/dataloader/impl/Assertions.java
@@ -2,28 +2,26 @@ package org.dataloader.impl;
 
 import org.dataloader.annotations.Internal;
 
-import java.util.Objects;
+import java.util.function.Supplier;
 
 @Internal
 public class Assertions {
 
-    public static void assertState(boolean state, String message) {
+    public static void assertState(boolean state, Supplier<String> message) {
         if (!state) {
-            throw new AssertionException(message);
+            throw new DataLoaderAssertionException(message.get());
         }
     }
 
     public static <T> T nonNull(T t) {
-        return Objects.requireNonNull(t, "nonNull object required");
+        return nonNull(t, () -> "nonNull object required");
     }
 
-    public static <T> T nonNull(T t, String message) {
-        return Objects.requireNonNull(t, message);
-    }
-
-    private static class AssertionException extends IllegalStateException {
-        public AssertionException(String message) {
-            super(message);
+    public static <T> T nonNull(T t, Supplier<String> message) {
+        if (t == null) {
+            throw new NullPointerException(message.get());
         }
+        return t;
     }
+
 }

--- a/src/main/java/org/dataloader/impl/DataLoaderAssertionException.java
+++ b/src/main/java/org/dataloader/impl/DataLoaderAssertionException.java
@@ -1,0 +1,7 @@
+package org.dataloader.impl;
+
+public class DataLoaderAssertionException extends IllegalStateException {
+    public DataLoaderAssertionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/dataloader/impl/PromisedValuesImpl.java
+++ b/src/main/java/org/dataloader/impl/PromisedValuesImpl.java
@@ -104,7 +104,7 @@ public class PromisedValuesImpl<T> implements PromisedValues<T> {
 
     @Override
     public T get(int index) {
-        assertState(isDone(), "The PromisedValues MUST be complete before calling the get() method");
+        assertState(isDone(), () -> "The PromisedValues MUST be complete before calling the get() method");
         try {
             CompletionStage<T> future = futures.get(index);
             return future.toCompletableFuture().get();
@@ -115,7 +115,7 @@ public class PromisedValuesImpl<T> implements PromisedValues<T> {
 
     @Override
     public List<T> toList() {
-        assertState(isDone(), "The PromisedValues MUST be complete before calling the toList() method");
+        assertState(isDone(), () -> "The PromisedValues MUST be complete before calling the toList() method");
         int size = size();
         List<T> list = new ArrayList<>(size);
         for (int index = 0; index < size; index++) {

--- a/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
+++ b/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
@@ -288,7 +288,9 @@ public class DataLoaderValueCacheTest {
         assertThat(loadCalls, equalTo(singletonList(asList("missC", "missD"))));
 
         List<Object> values = new ArrayList<>(customValueCache.asMap().values());
-        assertThat(values, equalTo(asList("a", "b", "missC", "missD")));
+        // it will only set back in values that are missed - it wont set in values that successfully
+        // came out of the cache
+        assertThat(values, equalTo(asList("missC", "missD")));
     }
 
     @Test

--- a/src/test/java/org/dataloader/TryTest.java
+++ b/src/test/java/org/dataloader/TryTest.java
@@ -11,7 +11,9 @@ import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("ConstantConditions")
 public class TryTest {
@@ -192,5 +194,13 @@ public class TryTest {
         sTry = sTry.recover(t -> "Hello World");
 
         assertSuccess(sTry, "Hello Again");
+    }
+
+    @Test
+    public void canAlwaysFail() {
+        Try<Object> failedTry = Try.alwaysFailed();
+
+        assertTrue(failedTry.isFailure());
+        assertFalse(failedTry.isSuccess());
     }
 }

--- a/src/test/java/org/dataloader/fixtures/CustomValueCache.java
+++ b/src/test/java/org/dataloader/fixtures/CustomValueCache.java
@@ -37,4 +37,8 @@ public class CustomValueCache implements ValueCache<String, Object> {
         store.clear();
         return CompletableFuture.completedFuture(null);
     }
+
+    public Map<String, Object> asMap() {
+        return store;
+    }
 }

--- a/src/test/java/org/dataloader/fixtures/TestKit.java
+++ b/src/test/java/org/dataloader/fixtures/TestKit.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.dataloader.impl.CompletableFutureKit.failedFuture;
 
 public class TestKit {
@@ -26,7 +26,7 @@ public class TestKit {
             @SuppressWarnings("unchecked")
             List<V> values = keys.stream()
                     .map(k -> (V) k)
-                    .collect(Collectors.toList());
+                    .collect(toList());
             return CompletableFuture.completedFuture(values);
         };
     }
@@ -61,5 +61,10 @@ public class TestKit {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+
+    public static <T> List<T> sort(Collection<? extends T> collection) {
+        return collection.stream().sorted().collect(toList());
     }
 }


### PR DESCRIPTION
The ValueCache is an async affair.

The previous PRs such as https://github.com/graphql-java/java-dataloader/pull/91 handled it badly because they made the "load" call asynchronous with repect to the method returning a CF that might need to be dispatched

This fixes this by approaching it differently.

The BatchLoader is an async method and hence we can call the ValueCache then, meaning given 10 keys, if it gets 6 from the cache first it need only batch call for 4 after wards.

The results are then combined together again.

This opens another possibility - that is being able to do "batch cache" lookups.  This has been added to ValueCache and if the implementation cant do batch lookup it just delegates back to the singleton `get` calls.

For something backed by say REDIS (which can do batch cache calls) this may improve performance

The batch size here is no bigger than the max batch size options

