### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.graphql-java:java-dataloader: 2.2.3'
+    compile 'com.graphql-java:java-dataloader: 3.1.0'
 }
 ```
 


### PR DESCRIPTION
Dependency was listed pretty far down in the README, below the numerous examples, this pulls it up higher and updates to the latest version (my guess is since it was so far down the version was missed, if this was intentional I'm happy to change it back!).