### PR TITLE
Fix invalid Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ apply plugin: 'groovy'
 
 jar {
     manifest {
-        attributes('Automatic-Module-Name': 'com.graphql-java')
+        attributes('Automatic-Module-Name': 'com.graphqljava')
     }
 }
 


### PR DESCRIPTION
This is the smallest change and consistent with graphql-java/graphql-java#2423, however it may make more sense to change to `org.dataloader` to match the package being used.

Fixes #101