### PR TITLE
Add @GuardedBy and remove redundant synchronized

### DIFF
--- a/src/main/java/org/dataloader/annotations/GuardedBy.java
+++ b/src/main/java/org/dataloader/annotations/GuardedBy.java
@@ -1,0 +1,21 @@
+package org.dataloader.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated element should be used only while holding the specified lock.
+ */
+@Target({FIELD, METHOD})
+@Retention(CLASS)
+public @interface GuardedBy {
+
+  /**
+   * The lock that should be held.
+   */
+  String value();
+}


### PR DESCRIPTION
As `@GuardedBy("dataLoader") ` describe, the thread is already hold `dataLoader ` lock when `loadFromCache`  is called.
https://github.com/graphql-java/java-dataloader/blob/4253050b302c6e342a42a67bdab094844ba643ff/src/main/java/org/dataloader/DataLoaderHelper.java#L102
