### PR TITLE
Convert NoOpValueCache#get return value to constant exception

### DIFF
--- a/src/main/java/org/dataloader/impl/NoOpValueCache.java
+++ b/src/main/java/org/dataloader/impl/NoOpValueCache.java
@@ -20,14 +20,16 @@ import java.util.concurrent.CompletableFuture;
 @Internal
 public class NoOpValueCache<K, V> implements ValueCache<K, V> {
 
-    public static NoOpValueCache<?, ?> NOOP = new NoOpValueCache<>();
+    public static final NoOpValueCache<?, ?> NOOP = new NoOpValueCache<>();
+
+    private static final Exception NOOP_GET_FAILURE = new UnsupportedOperationException();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public CompletableFuture<V> get(K key) {
-        return CompletableFutureKit.failedFuture(new UnsupportedOperationException());
+        return CompletableFutureKit.failedFuture(NOOP_GET_FAILURE);
     }
 
     /**


### PR DESCRIPTION
**Describe the bug**
A UnsupportedOperationException was being created on every NoOpValueCache#get call. I tested one of my queries with some dataloaders and 100.000 query operations over three waves. The result was 700.000 UnsupportedOperationException initializations!

I was stress testing my DGS Framework/GraphQL Java API that uses DataLoader, when I saw this:
![afbeelding](https://user-images.githubusercontent.com/30464310/153713764-0bc5a1cf-a4c1-4257-8889-3df5b85436e3.png)

Stacktrace:
![afbeelding](https://user-images.githubusercontent.com/30464310/153713911-d3a6ec9a-80d7-4388-abf3-540aa538d92e.png)

**To Reproduce**
Use DataLoader+GraphQL Java with the NoOpValueCache and analyze with JMC or JFR (`jdk.JavaExceptionThrow` event)
