### PR TITLE
Short circuit value cache look up to avoid object allocations

### DIFF
--- a/src/main/java/org/dataloader/ValueCache.java
+++ b/src/main/java/org/dataloader/ValueCache.java
@@ -154,7 +154,7 @@ public interface ValueCache<K, V> {
      */
     class ValueCachingNotSupported extends UnsupportedOperationException {
         @Override
-        public synchronized Throwable fillInStackTrace() {
+        public Throwable fillInStackTrace() {
             return this;
         }
     }

--- a/src/main/java/org/dataloader/impl/NoOpValueCache.java
+++ b/src/main/java/org/dataloader/impl/NoOpValueCache.java
@@ -1,9 +1,11 @@
 package org.dataloader.impl;
 
 
+import org.dataloader.Try;
 import org.dataloader.ValueCache;
 import org.dataloader.annotations.Internal;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -20,14 +22,27 @@ import java.util.concurrent.CompletableFuture;
 @Internal
 public class NoOpValueCache<K, V> implements ValueCache<K, V> {
 
-    public static NoOpValueCache<?, ?> NOOP = new NoOpValueCache<>();
+    /**
+     * a no op value cache instance
+     */
+    public static final NoOpValueCache<?, ?> NOOP = new NoOpValueCache<>();
+
+    // avoid object allocation by using a final field
+    private final ValueCachingNotSupported NOT_SUPPORTED = new ValueCachingNotSupported();
+    private final CompletableFuture<V> NOT_SUPPORTED_CF = CompletableFutureKit.failedFuture(NOT_SUPPORTED);
+    private final CompletableFuture<Void> NOT_SUPPORTED_VOID_CF = CompletableFuture.completedFuture(null);
 
     /**
      * {@inheritDoc}
      */
     @Override
     public CompletableFuture<V> get(K key) {
-        return CompletableFutureKit.failedFuture(new UnsupportedOperationException());
+        return NOT_SUPPORTED_CF;
+    }
+
+    @Override
+    public CompletableFuture<List<Try<V>>> getValues(List<K> keys) throws ValueCachingNotSupported {
+        throw NOT_SUPPORTED;
     }
 
     /**
@@ -35,7 +50,12 @@ public class NoOpValueCache<K, V> implements ValueCache<K, V> {
      */
     @Override
     public CompletableFuture<V> set(K key, V value) {
-        return CompletableFuture.completedFuture(value);
+        return NOT_SUPPORTED_CF;
+    }
+
+    @Override
+    public CompletableFuture<List<V>> setValues(List<K> keys, List<V> values) throws ValueCachingNotSupported {
+        throw NOT_SUPPORTED;
     }
 
     /**
@@ -43,7 +63,7 @@ public class NoOpValueCache<K, V> implements ValueCache<K, V> {
      */
     @Override
     public CompletableFuture<Void> delete(K key) {
-        return CompletableFuture.completedFuture(null);
+        return NOT_SUPPORTED_VOID_CF;
     }
 
     /**
@@ -51,6 +71,6 @@ public class NoOpValueCache<K, V> implements ValueCache<K, V> {
      */
     @Override
     public CompletableFuture<Void> clear() {
-        return CompletableFuture.completedFuture(null);
+        return NOT_SUPPORTED_VOID_CF;
     }
 }


### PR DESCRIPTION
The original PR : https://github.com/graphql-java/java-dataloader/pull/108 shows we are allocating too many objects.

This takes it further by introducing a fast exception to allow a `ValueCache` to short circuit out of a look up.

This is then used by the default NoopValueCache and hences saves memory and processing for every one  NOT using a ValueCache