### PR TITLE
Implement recursive dispatching

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/DataLoaderRegistry.java
@@ -4,8 +4,6 @@ import org.dataloader.annotations.PublicApi;
 import org.dataloader.stats.Statistics;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -170,7 +170,7 @@ public class DataLoaderRegistryTest {
     }
 
     @Test
-    public void composed_dispatch_counts_and_stats_are_maintained() {
+    public void composed_dispatch_counts_are_maintained() {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
@@ -207,14 +207,6 @@ public class DataLoaderRegistryTest {
 
         assertThat("Zero dispatched keys in second iteration", dispatchedKeys2.join(), equalTo(0));
         assertThat("Zero dispatch depth after second iteration done", registry.dispatchDepth(), equalTo(0));
-
-        Statistics statistics = registry.getStatistics();
-
-        assertThat(statistics.getLoadCount(), equalTo(12L));
-        assertThat(statistics.getBatchLoadCount(), equalTo(6L));
-        assertThat(statistics.getCacheHitCount(), equalTo(6L));
-        assertThat(statistics.getLoadErrorCount(), equalTo(0L));
-        assertThat(statistics.getBatchLoadExceptionCount(), equalTo(0L));
 
         assertThat(test1.join(), equalTo(103));
         assertThat(test2.join(), equalTo(203));


### PR DESCRIPTION
This PR may be related to #54 

The goal of this PR is to support composition of data loader invocations.
- when using 'thenCompose' method to chain data loader calls, all composed load calls will be dispatched
- the methods 'dispatchAll' or 'dispatchAllWithCount' will recur until there are no more calls to dispatch
- the method 'dispatchAllWithCount' will block in order to return the counter of dispatches

Thanks to @npiguet for the original idea and code review.