### PR TITLE
Make NoOpStatisticsCollector to be default StatisticsCollector

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -18,7 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicApi;
 import org.dataloader.impl.Assertions;
-import org.dataloader.stats.SimpleStatisticsCollector;
+import org.dataloader.stats.NoOpStatisticsCollector;
 import org.dataloader.stats.StatisticsCollector;
 
 import java.util.Optional;
@@ -55,7 +55,7 @@ public class DataLoaderOptions {
         cachingEnabled = true;
         cachingExceptionsEnabled = true;
         maxBatchSize = -1;
-        statisticsCollector = SimpleStatisticsCollector::new;
+        statisticsCollector = NoOpStatisticsCollector::new;
         environmentProvider = NULL_PROVIDER;
         valueCacheOptions = ValueCacheOptions.newOptions();
     }

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -1,5 +1,6 @@
 package org.dataloader;
 
+import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.Statistics;
 import org.junit.Test;
 
@@ -77,9 +78,15 @@ public class DataLoaderRegistryTest {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
-        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+        );
+        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+        );
+        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+        );
 
         registry.register("a", dlA).register("b", dlB).register("c", dlC);
 

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -24,7 +24,9 @@ public class DataLoaderStatsTest {
     @Test
     public void stats_are_collected_by_default() {
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
-        DataLoader<String, String> loader = newDataLoader(batchLoader);
+        DataLoader<String, String> loader = newDataLoader(batchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+        );
 
         loader.load("A");
         loader.load("B");
@@ -154,7 +156,9 @@ public class DataLoaderStatsTest {
 
     @Test
     public void stats_are_collected_on_exceptions() {
-        DataLoader<String, String> loader = DataLoaderFactory.newDataLoaderWithTry(batchLoaderThatBlows);
+        DataLoader<String, String> loader = DataLoaderFactory.newDataLoaderWithTry(batchLoaderThatBlows,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+        );
 
         loader.load("A");
         loader.load("exception");


### PR DESCRIPTION
We rarely need statistics info from dataLoader, and it would be better to make NoOpStatisticsCollector default, just like guava cache.