### PR TITLE
feat: make cache map values accesible for read only purposes

### DIFF
--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -19,6 +19,7 @@ package org.dataloader;
 import org.dataloader.annotations.PublicSpi;
 import org.dataloader.impl.DefaultCacheMap;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -72,6 +73,12 @@ public interface CacheMap<K, V> {
      * @return the cached value, or {@code null} if not found (depends on cache implementation)
      */
     CompletableFuture<V> get(K key);
+
+    /**
+     * Gets a collection of CompletableFutures of the cache map.
+     * @return the collection of cached values
+     */
+    Collection<CompletableFuture<V>> getAll();
 
     /**
      * Creates a new cache map entry with the specified key and value, or updates the value if the key already exists.

--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -76,7 +76,7 @@ public interface CacheMap<K, V> {
     CompletableFuture<V> get(K key);
 
     /**
-     * Gets a read-only collection of CompletableFutures of the cache map.
+     * Gets a collection of CompletableFutures from the cache map.
      * @return the collection of cached values
      */
     Collection<CompletableFuture<V>> getAll();

--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -20,6 +20,7 @@ import org.dataloader.annotations.PublicSpi;
 import org.dataloader.impl.DefaultCacheMap;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -75,7 +76,7 @@ public interface CacheMap<K, V> {
     CompletableFuture<V> get(K key);
 
     /**
-     * Gets a collection of CompletableFutures of the cache map.
+     * Gets a read-only collection of CompletableFutures of the cache map.
      * @return the collection of cached values
      */
     Collection<CompletableFuture<V>> getAll();

--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -20,7 +20,6 @@ import org.dataloader.annotations.PublicSpi;
 import org.dataloader.impl.DefaultCacheMap;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 /**

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -25,10 +25,7 @@ import org.dataloader.stats.StatisticsCollector;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -452,6 +449,13 @@ public class DataLoader<K, V> {
         return Duration.between(helper.getLastDispatchTime(), helper.now());
     }
 
+    /**
+     * This returns a read-only collection of CompletableFutures of the cache map.
+     * @return read-only collection of CompletableFutures
+     */
+    public Collection<CompletableFuture<V>> getCacheFutures() {
+        return helper.getCacheFutures();
+    }
 
     /**
      * Requests to load the data with the specified key asynchronously, and returns a future of the resulting value.

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -458,7 +458,7 @@ public class DataLoader<K, V> {
      * @return read-only collection of CompletableFutures
      */
     public Collection<CompletableFuture<V>> getCacheFutures() {
-        return helper.getCacheFutures();
+        return Collections.unmodifiableCollection(futureCache.getAll());
     }
 
     /**

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -26,7 +26,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -454,14 +453,6 @@ public class DataLoader<K, V> {
     }
 
     /**
-     * This returns a read-only collection of CompletableFutures of the cache map.
-     * @return read-only collection of CompletableFutures
-     */
-    public Collection<CompletableFuture<V>> getCacheFutures() {
-        return Collections.unmodifiableCollection(futureCache.getAll());
-    }
-
-    /**
      * Requests to load the data with the specified key asynchronously, and returns a future of the resulting value.
      * <p>
      * If batching is enabled (the default), you'll have to call {@link DataLoader#dispatch()} at a later stage to
@@ -758,6 +749,23 @@ public class DataLoader<K, V> {
      */
     public Statistics getStatistics() {
         return stats.getStatistics();
+    }
+
+    /**
+     * Gets the cacheMap associated with this data loader passed in via {@link DataLoaderOptions#cacheMap()}
+     * @return the cacheMap of this data loader
+     */
+    public CacheMap<Object, V> getCacheMap() {
+        return futureCache;
+    }
+
+
+    /**
+     * Gets the valueCache associated with this data loader passed in via {@link DataLoaderOptions#valueCache()}
+     * @return the valueCache of this data loader
+     */
+    public ValueCache<K, V> getValueCache() {
+        return valueCache;
     }
 
 }

--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -25,7 +25,11 @@ import org.dataloader.stats.StatisticsCollector;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -7,7 +7,14 @@ import org.dataloader.stats.StatisticsCollector;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -7,13 +7,7 @@ import org.dataloader.stats.StatisticsCollector;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -97,6 +91,10 @@ class DataLoaderHelper<K, V> {
 
     public Instant getLastDispatchTime() {
         return lastDispatchTime.get();
+    }
+
+    public Collection<CompletableFuture<V>> getCacheFutures() {
+        return Collections.unmodifiableCollection(futureCache.getAll());
     }
 
     Optional<CompletableFuture<V>> getIfPresent(K key) {

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -9,7 +9,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,10 +97,6 @@ class DataLoaderHelper<K, V> {
 
     public Instant getLastDispatchTime() {
         return lastDispatchTime.get();
-    }
-
-    public Collection<CompletableFuture<V>> getCacheFutures() {
-        return Collections.unmodifiableCollection(futureCache.getAll());
     }
 
     Optional<CompletableFuture<V>> getIfPresent(K key) {

--- a/src/main/java/org/dataloader/impl/DefaultCacheMap.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheMap.java
@@ -19,8 +19,7 @@ package org.dataloader.impl;
 import org.dataloader.CacheMap;
 import org.dataloader.annotations.Internal;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -58,6 +57,14 @@ public class DefaultCacheMap<K, V> implements CacheMap<K, V> {
     @Override
     public CompletableFuture<V> get(K key) {
         return cache.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<CompletableFuture<V>> getAll() {
+        return cache.values();
     }
 
     /**

--- a/src/main/java/org/dataloader/impl/DefaultCacheMap.java
+++ b/src/main/java/org/dataloader/impl/DefaultCacheMap.java
@@ -19,7 +19,9 @@ package org.dataloader.impl;
 import org.dataloader.CacheMap;
 import org.dataloader.annotations.Internal;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -16,7 +16,11 @@ import org.dataloader.stats.Statistics;
 import org.dataloader.stats.ThreadLocalStatisticsCollector;
 
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -16,10 +16,7 @@ import org.dataloader.stats.Statistics;
 import org.dataloader.stats.ThreadLocalStatisticsCollector;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -218,6 +215,11 @@ public class ReadmeExamples {
 
         @Override
         public CompletableFuture<Object> get(Object key) {
+            return null;
+        }
+
+        @Override
+        public Collection<CompletableFuture<Object>> getAll() {
             return null;
         }
 

--- a/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
+++ b/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
@@ -1,0 +1,60 @@
+package org.dataloader;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for cacheMap functionality..
+ */
+public class DataLoaderCacheMapTest {
+
+    private <T> BatchLoader<T, T> keysAsValues() {
+        return CompletableFuture::completedFuture;
+    }
+
+    @Test
+    public void should_provide_all_futures_from_cache() {
+        DataLoader<Integer, Integer> dataLoader = newDataLoader(keysAsValues());
+
+        dataLoader.load(1);
+        dataLoader.load(2);
+        dataLoader.load(1);
+
+        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
+        assertThat(futures.size(), equalTo(2));
+    }
+
+    @Test
+    public void should_access_to_future_dependants() {
+        DataLoader<Integer, Integer> dataLoader = newDataLoader(keysAsValues());
+
+        dataLoader.load(1).handle((v, t) -> t);
+        dataLoader.load(2).handle((v, t) -> t);
+        dataLoader.load(1).handle((v, t) -> t);
+
+        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
+
+        List<CompletableFuture<Integer>> futuresList = new ArrayList<>(futures);
+        assertThat(futuresList.get(0).getNumberOfDependents(), equalTo(2));
+        assertThat(futuresList.get(1).getNumberOfDependents(), equalTo(1));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_throw_exception__on_mutation_attempt() {
+        DataLoader<Integer, Integer> dataLoader = newDataLoader(keysAsValues());
+
+        dataLoader.load(1).handle((v, t) -> t);
+
+        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
+
+        futures.add(CompletableFuture.completedFuture(2));
+    }
+}

--- a/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
+++ b/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
@@ -28,7 +28,7 @@ public class DataLoaderCacheMapTest {
         dataLoader.load(2);
         dataLoader.load(1);
 
-        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
+        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheMap().getAll();
         assertThat(futures.size(), equalTo(2));
     }
 
@@ -40,21 +40,10 @@ public class DataLoaderCacheMapTest {
         dataLoader.load(2).handle((v, t) -> t);
         dataLoader.load(1).handle((v, t) -> t);
 
-        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
+        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheMap().getAll();
 
         List<CompletableFuture<Integer>> futuresList = new ArrayList<>(futures);
         assertThat(futuresList.get(0).getNumberOfDependents(), equalTo(2));
         assertThat(futuresList.get(1).getNumberOfDependents(), equalTo(1));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void should_throw_exception__on_mutation_attempt() {
-        DataLoader<Integer, Integer> dataLoader = newDataLoader(keysAsValues());
-
-        dataLoader.load(1).handle((v, t) -> t);
-
-        Collection<CompletableFuture<Integer>> futures = dataLoader.getCacheFutures();
-
-        futures.add(CompletableFuture.completedFuture(2));
     }
 }

--- a/src/test/java/org/dataloader/DataLoaderIfPresentTest.java
+++ b/src/test/java/org/dataloader/DataLoaderIfPresentTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
-
 /**
  * Tests for IfPresent and IfCompleted functionality.
  */

--- a/src/test/java/org/dataloader/fixtures/CustomCacheMap.java
+++ b/src/test/java/org/dataloader/fixtures/CustomCacheMap.java
@@ -2,6 +2,7 @@ package org.dataloader.fixtures;
 
 import org.dataloader.CacheMap;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +23,11 @@ public class CustomCacheMap implements CacheMap<String, Object> {
     @Override
     public CompletableFuture<Object> get(String key) {
         return stash.get(key);
+    }
+
+    @Override
+    public Collection<CompletableFuture<Object>> getAll() {
+        return stash.values();
     }
 
     @Override


### PR DESCRIPTION
in an attempt so write a better `Instrumentation` that could dispatch a `DataLoaderRegistry` in a more optimized way [we created a custom Instrumentation](https://opensource.expediagroup.com/graphql-kotlin/docs/server/data-loader/data-loader-instrumentation#dispatching-by-synchronous-execution-exhaustion) that tracks the state of each `ExecutionStrategy` of an `ExecutionInput` and dispatch the DataLoaderRegistry when no more synchronous code could be executed.

more information

https://github.com/graphql-java/graphql-java/discussions/2715

this PR adds a method to the `DataLoader` class that provides a read-only list of CacheMaps associated with the DataLoader, this will help to keep track of the `numberOfDependents` of each future.

by doing this we would also be solving a problem highlighted here

https://github.com/graphql-java/graphql-java/issues/1198

considering this queries:

`astronaut` can have many `mission` 
`mission` can have many `planets`

in order to access to astronaut planets we need 2 `DataLoaders` to be chained in the `planets` resolver
1. GetMissionsByAstronaut
2. GetPlanetsByMission

```graphql
query GetAstronautPlanets {
    astronaut(id: 1) {
        name
        planets {
            name
        }
    }
}
```
```graphql
query GetAstronautMissions {
    astronaut(id: 3) {
        name
        missions {
            designation
            planets {
                name
            }
        }
    }
}
```

With the custom `DataLoaderSyncExecutionExhaustedInstrumentation` and this change we were able to get data for those 2 queries by dispatching those 2 dataLoader only once.

we wrote some logic to decorate a `DataLoaderRegistry` to make `CacheMap` values public for read-only purposes and that helped to achieve above logic

more detailed test here

https://github.com/ExpediaGroup/graphql-kotlin/blob/1758f9c4fed47f086891c9340ebc995eca1e9083/executions/graphql-kotlin-dataloader-instrumentation/src/test/kotlin/com/expediagroup/graphql/dataloader/instrumentation/syncexhaustion/DataLoaderSyncExecutionExhaustedInstrumentationTest.kt#L345
