### PR TITLE
Changed Automatic Module Name to org.dataloader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ apply plugin: 'groovy'
 
 jar {
     manifest {
-        attributes('Automatic-Module-Name': 'com.graphqljava',
+        attributes('Automatic-Module-Name': 'org.dataloader',
 		'-exportcontents': 'org.dataloader.*',
 		'-removeheaders': 'Private-Package')
     }


### PR DESCRIPTION
Fixes #110 

[graphql-java](https://github.com/graphql-java/graphql-java) has the Automatic Module Name `com.graphqljava`, and it also directly depends on java-dataloader. Since java-dataloader also has the Automatic Module Name `com.graphqljava`, the module system cannot determine which module to use and so any usage of graphql-java with the module path is instantly broken.

This patch changes the Automatic Module Name to `org.dataloader` since that's the root package name.

Given that:
- Automatic Module Name is only relevant when using the module path
- java-dataloader is inherently always used with graphql-java, and so in its current state on the module path is completely broken

then I believe this is a passive change - not sure what the release process is around bumping versions since this is my first time contributing to this project. Let me know if I need to do anything else!