### PR TITLE
Add context objects to StatisticsCollector methods

### DIFF
--- a/src/main/java/org/dataloader/stats/DelegatingStatisticsCollector.java
+++ b/src/main/java/org/dataloader/stats/DelegatingStatisticsCollector.java
@@ -1,5 +1,11 @@
 package org.dataloader.stats;
 
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
+
 import static org.dataloader.impl.Assertions.nonNull;
 
 /**
@@ -20,33 +26,63 @@ public class DelegatingStatisticsCollector implements StatisticsCollector {
     }
 
     @Override
+    public <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
+        delegateCollector.incrementLoadCount(context);
+        return collector.incrementLoadCount(context);
+    }
+
+    @Deprecated
+    @Override
     public long incrementLoadCount() {
-        delegateCollector.incrementLoadCount();
-        return collector.incrementLoadCount();
+        return incrementLoadCount(null);
     }
 
     @Override
-    public long incrementBatchLoadCountBy(long delta) {
-        delegateCollector.incrementBatchLoadCountBy(delta);
-        return collector.incrementBatchLoadCountBy(delta);
+    public <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+        delegateCollector.incrementLoadErrorCount(context);
+        return collector.incrementLoadErrorCount(context);
     }
 
-    @Override
-    public long incrementCacheHitCount() {
-        delegateCollector.incrementCacheHitCount();
-        return collector.incrementCacheHitCount();
-    }
-
+    @Deprecated
     @Override
     public long incrementLoadErrorCount() {
-        delegateCollector.incrementLoadErrorCount();
-        return collector.incrementLoadErrorCount();
+        return incrementLoadErrorCount(null);
     }
 
     @Override
+    public <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
+        delegateCollector.incrementBatchLoadCountBy(delta, context);
+        return collector.incrementBatchLoadCountBy(delta, context);
+    }
+
+    @Deprecated
+    @Override
+    public long incrementBatchLoadCountBy(long delta) {
+        return incrementBatchLoadCountBy(delta, null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
+        delegateCollector.incrementBatchLoadExceptionCount(context);
+        return collector.incrementBatchLoadExceptionCount(context);
+    }
+
+    @Deprecated
+    @Override
     public long incrementBatchLoadExceptionCount() {
-        delegateCollector.incrementBatchLoadExceptionCount();
-        return collector.incrementBatchLoadExceptionCount();
+        return incrementBatchLoadExceptionCount(null);
+    }
+
+    @Override
+    public <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
+        delegateCollector.incrementCacheHitCount(context);
+        return collector.incrementCacheHitCount(context);
+    }
+
+    @Deprecated
+    @Override
+    public long incrementCacheHitCount() {
+        return incrementCacheHitCount(null);
     }
 
     /**

--- a/src/main/java/org/dataloader/stats/NoOpStatisticsCollector.java
+++ b/src/main/java/org/dataloader/stats/NoOpStatisticsCollector.java
@@ -1,5 +1,11 @@
 package org.dataloader.stats;
 
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
+
 /**
  * A statistics collector that does nothing
  */
@@ -8,28 +14,58 @@ public class NoOpStatisticsCollector implements StatisticsCollector {
     private static final Statistics ZERO_STATS = new Statistics();
 
     @Override
-    public long incrementLoadCount() {
+    public <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
         return 0;
     }
 
+    @Deprecated
+    @Override
+    public long incrementLoadCount() {
+        return incrementLoadCount(null);
+    }
+
+    @Override
+    public <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+        return 0;
+    }
+
+    @Deprecated
     @Override
     public long incrementLoadErrorCount() {
+        return incrementLoadErrorCount(null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
         return 0;
     }
 
+    @Deprecated
     @Override
     public long incrementBatchLoadCountBy(long delta) {
+        return incrementBatchLoadCountBy(delta, null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
         return 0;
     }
 
+    @Deprecated
     @Override
     public long incrementBatchLoadExceptionCount() {
-        return 0;
+        return incrementBatchLoadExceptionCount(null);
     }
 
     @Override
-    public long incrementCacheHitCount() {
+    public <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
         return 0;
+    }
+
+    @Deprecated
+    @Override
+    public long incrementCacheHitCount() {
+        return incrementCacheHitCount(null);
     }
 
     @Override

--- a/src/main/java/org/dataloader/stats/SimpleStatisticsCollector.java
+++ b/src/main/java/org/dataloader/stats/SimpleStatisticsCollector.java
@@ -1,5 +1,11 @@
 package org.dataloader.stats;
 
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -17,30 +23,59 @@ public class SimpleStatisticsCollector implements StatisticsCollector {
     private final AtomicLong loadErrorCount = new AtomicLong();
 
     @Override
-    public long incrementLoadCount() {
+    public <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
         return loadCount.incrementAndGet();
     }
 
+    @Deprecated
+    @Override
+    public long incrementLoadCount() {
+        return incrementLoadCount(null);
+    }
 
     @Override
-    public long incrementBatchLoadCountBy(long delta) {
+    public <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+        return loadErrorCount.incrementAndGet();
+    }
+
+    @Deprecated
+    @Override
+    public long incrementLoadErrorCount() {
+        return incrementLoadErrorCount(null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
         batchInvokeCount.incrementAndGet();
         return batchLoadCount.addAndGet(delta);
     }
 
+    @Deprecated
     @Override
-    public long incrementCacheHitCount() {
+    public long incrementBatchLoadCountBy(long delta) {
+        return incrementBatchLoadCountBy(delta, null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
+        return batchLoadExceptionCount.incrementAndGet();
+    }
+
+    @Deprecated
+    @Override
+    public long incrementBatchLoadExceptionCount() {
+        return incrementBatchLoadExceptionCount(null);
+    }
+
+    @Override
+    public <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
         return cacheHitCount.incrementAndGet();
     }
 
+    @Deprecated
     @Override
-    public long incrementLoadErrorCount() {
-        return loadErrorCount.incrementAndGet();
-    }
-
-    @Override
-    public long incrementBatchLoadExceptionCount() {
-        return batchLoadExceptionCount.incrementAndGet();
+    public long incrementCacheHitCount() {
+        return incrementCacheHitCount(null);
     }
 
     @Override

--- a/src/main/java/org/dataloader/stats/StatisticsCollector.java
+++ b/src/main/java/org/dataloader/stats/StatisticsCollector.java
@@ -1,6 +1,11 @@
 package org.dataloader.stats;
 
 import org.dataloader.annotations.PublicSpi;
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
 
 /**
  * This allows statistics to be collected for {@link org.dataloader.DataLoader} operations
@@ -11,38 +16,109 @@ public interface StatisticsCollector {
     /**
      * Called to increment the number of loads
      *
+     * @param <K> the class of the key in the data loader
+     * @param context the context containing metadata of the data loader invocation
+     *
      * @return the current value after increment
      */
+    default <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
+        return incrementLoadCount();
+    }
+
+    /**
+     * Called to increment the number of loads
+     *
+     * @deprecated use {@link #incrementLoadCount(IncrementLoadCountStatisticsContext)}
+     * @return the current value after increment
+     */
+    @Deprecated
     long incrementLoadCount();
 
     /**
      * Called to increment the number of loads that resulted in an object deemed in error
      *
+     * @param <K> the class of the key in the data loader
+     * @param context the context containing metadata of the data loader invocation
+     *
      * @return the current value after increment
      */
+    default <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+        return incrementLoadErrorCount();
+    }
+
+    /**
+     * Called to increment the number of loads that resulted in an object deemed in error
+     *
+     * @deprecated use {@link #incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext)}
+     * @return the current value after increment
+     */
+    @Deprecated
     long incrementLoadErrorCount();
+
+    /**
+     * Called to increment the number of batch loads
+     *
+     * @param <K> the class of the key in the data loader
+     * @param delta how much to add to the count
+     * @param context the context containing metadata of the data loader invocation
+     *
+     * @return the current value after increment
+     */
+    default <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
+        return incrementBatchLoadCountBy(delta);
+    }
 
     /**
      * Called to increment the number of batch loads
      *
      * @param delta how much to add to the count
      *
+     * @deprecated use {@link #incrementBatchLoadCountBy(long, IncrementBatchLoadCountByStatisticsContext)}
      * @return the current value after increment
      */
+    @Deprecated
     long incrementBatchLoadCountBy(long delta);
 
     /**
      * Called to increment the number of batch loads exceptions
      *
+     * @param <K> the class of the key in the data loader
+     * @param context the context containing metadata of the data loader invocation
+     *
      * @return the current value after increment
      */
+    default <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
+        return incrementBatchLoadExceptionCount();
+    }
+
+    /**
+     * Called to increment the number of batch loads exceptions
+     *
+     * @deprecated use {@link #incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext)}
+     * @return the current value after increment
+     */
+    @Deprecated
     long incrementBatchLoadExceptionCount();
 
     /**
      * Called to increment the number of cache hits
      *
+     * @param <K> the class of the key in the data loader
+     * @param context the context containing metadata of the data loader invocation
+     *
      * @return the current value after increment
      */
+    default <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
+        return incrementCacheHitCount();
+    }
+
+    /**
+     * Called to increment the number of cache hits
+     *
+     * @deprecated use {@link #incrementCacheHitCount(IncrementCacheHitCountStatisticsContext)}
+     * @return the current value after increment
+     */
+    @Deprecated
     long incrementCacheHitCount();
 
     /**

--- a/src/main/java/org/dataloader/stats/ThreadLocalStatisticsCollector.java
+++ b/src/main/java/org/dataloader/stats/ThreadLocalStatisticsCollector.java
@@ -1,5 +1,11 @@
 package org.dataloader.stats;
 
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
+
 /**
  * This can collect statistics per thread as well as in an overall sense.  This allows you to snapshot stats for a web request say
  * as well as all requests.
@@ -29,33 +35,63 @@ public class ThreadLocalStatisticsCollector implements StatisticsCollector {
     }
 
     @Override
+    public <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
+        overallCollector.incrementLoadCount(context);
+        return collector.get().incrementLoadCount(context);
+    }
+
+    @Deprecated
+    @Override
     public long incrementLoadCount() {
-        overallCollector.incrementLoadCount();
-        return collector.get().incrementLoadCount();
+        return incrementLoadCount(null);
     }
 
     @Override
-    public long incrementBatchLoadCountBy(long delta) {
-        overallCollector.incrementBatchLoadCountBy(delta);
-        return collector.get().incrementBatchLoadCountBy(delta);
+    public <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+        overallCollector.incrementLoadErrorCount(context);
+        return collector.get().incrementLoadErrorCount(context);
     }
 
-    @Override
-    public long incrementCacheHitCount() {
-        overallCollector.incrementCacheHitCount();
-        return collector.get().incrementCacheHitCount();
-    }
-
+    @Deprecated
     @Override
     public long incrementLoadErrorCount() {
-        overallCollector.incrementLoadErrorCount();
-        return collector.get().incrementLoadErrorCount();
+        return incrementLoadErrorCount(null);
     }
 
     @Override
+    public <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
+        overallCollector.incrementBatchLoadCountBy(delta, context);
+        return collector.get().incrementBatchLoadCountBy(delta, context);
+    }
+
+    @Deprecated
+    @Override
+    public long incrementBatchLoadCountBy(long delta) {
+        return incrementBatchLoadCountBy(delta, null);
+    }
+
+    @Override
+    public <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
+        overallCollector.incrementBatchLoadExceptionCount(context);
+        return collector.get().incrementBatchLoadExceptionCount(context);
+    }
+
+    @Deprecated
+    @Override
     public long incrementBatchLoadExceptionCount() {
-        overallCollector.incrementBatchLoadExceptionCount();
-        return collector.get().incrementBatchLoadExceptionCount();
+        return incrementBatchLoadExceptionCount(null);
+    }
+
+    @Override
+    public <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
+        overallCollector.incrementCacheHitCount(context);
+        return collector.get().incrementCacheHitCount(context);
+    }
+
+    @Deprecated
+    @Override
+    public long incrementCacheHitCount() {
+        return incrementCacheHitCount(null);
     }
 
     /**

--- a/src/main/java/org/dataloader/stats/context/IncrementBatchLoadCountByStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementBatchLoadCountByStatisticsContext.java
@@ -1,0 +1,28 @@
+package org.dataloader.stats.context;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IncrementBatchLoadCountByStatisticsContext<K> {
+
+    private final List<K> keys;
+    private final List<Object> callContexts;
+
+    public IncrementBatchLoadCountByStatisticsContext(List<K> keys, List<Object> callContexts) {
+        this.keys = keys;
+        this.callContexts = callContexts;
+    }
+
+    public IncrementBatchLoadCountByStatisticsContext(K key, Object callContext) {
+        this.keys = Collections.singletonList(key);
+        this.callContexts = Collections.singletonList(callContext);
+    }
+
+    public List<K> getKeys() {
+        return keys;
+    }
+
+    public List<Object> getCallContexts() {
+        return callContexts;
+    }
+}

--- a/src/main/java/org/dataloader/stats/context/IncrementBatchLoadCountByStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementBatchLoadCountByStatisticsContext.java
@@ -14,8 +14,7 @@ public class IncrementBatchLoadCountByStatisticsContext<K> {
     }
 
     public IncrementBatchLoadCountByStatisticsContext(K key, Object callContext) {
-        this.keys = Collections.singletonList(key);
-        this.callContexts = Collections.singletonList(callContext);
+        this(Collections.singletonList(key), Collections.singletonList(callContext));
     }
 
     public List<K> getKeys() {

--- a/src/main/java/org/dataloader/stats/context/IncrementBatchLoadExceptionCountStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementBatchLoadExceptionCountStatisticsContext.java
@@ -1,0 +1,22 @@
+package org.dataloader.stats.context;
+
+import java.util.List;
+
+public class IncrementBatchLoadExceptionCountStatisticsContext<K> {
+
+    private final List<K> keys;
+    private final List<Object> callContexts;
+
+    public IncrementBatchLoadExceptionCountStatisticsContext(List<K> keys, List<Object> callContexts) {
+        this.keys = keys;
+        this.callContexts = callContexts;
+    }
+
+    public List<K> getKeys() {
+        return keys;
+    }
+
+    public List<Object> getCallContexts() {
+        return callContexts;
+    }
+}

--- a/src/main/java/org/dataloader/stats/context/IncrementCacheHitCountStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementCacheHitCountStatisticsContext.java
@@ -11,8 +11,7 @@ public class IncrementCacheHitCountStatisticsContext<K> {
     }
 
     public IncrementCacheHitCountStatisticsContext(K key) {
-        this.key = key;
-        this.callContext = null;
+        this(key, null);
     }
 
     public K getKey() {

--- a/src/main/java/org/dataloader/stats/context/IncrementCacheHitCountStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementCacheHitCountStatisticsContext.java
@@ -1,0 +1,25 @@
+package org.dataloader.stats.context;
+
+public class IncrementCacheHitCountStatisticsContext<K> {
+
+    private final K key;
+    private final Object callContext;
+
+    public IncrementCacheHitCountStatisticsContext(K key, Object callContext) {
+        this.key = key;
+        this.callContext = callContext;
+    }
+
+    public IncrementCacheHitCountStatisticsContext(K key) {
+        this.key = key;
+        this.callContext = null;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public Object getCallContext() {
+        return callContext;
+    }
+}

--- a/src/main/java/org/dataloader/stats/context/IncrementLoadCountStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementLoadCountStatisticsContext.java
@@ -1,0 +1,20 @@
+package org.dataloader.stats.context;
+
+public class IncrementLoadCountStatisticsContext<K> {
+
+    private final K key;
+    private final Object callContext;
+
+    public IncrementLoadCountStatisticsContext(K key, Object callContext) {
+        this.key = key;
+        this.callContext = callContext;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public Object getCallContext() {
+        return callContext;
+    }
+}

--- a/src/main/java/org/dataloader/stats/context/IncrementLoadErrorCountStatisticsContext.java
+++ b/src/main/java/org/dataloader/stats/context/IncrementLoadErrorCountStatisticsContext.java
@@ -1,0 +1,20 @@
+package org.dataloader.stats.context;
+
+public class IncrementLoadErrorCountStatisticsContext<K> {
+
+    private final K key;
+    private final Object callContext;
+
+    public IncrementLoadErrorCountStatisticsContext(K key, Object callContext) {
+        this.key = key;
+        this.callContext = callContext;
+    }
+
+    public K getKey() {
+        return key;
+    }
+
+    public Object getCallContext() {
+        return callContext;
+    }
+}

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -4,6 +4,8 @@ import org.dataloader.impl.CompletableFutureKit;
 import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.Statistics;
 import org.dataloader.stats.StatisticsCollector;
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -63,8 +65,8 @@ public class DataLoaderStatsTest {
     public void stats_are_collected_with_specified_collector() {
         // lets prime it with some numbers so we know its ours
         StatisticsCollector collector = new SimpleStatisticsCollector();
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
 
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
         DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().setStatisticsCollector(() -> collector);

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -5,7 +5,10 @@ import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.Statistics;
 import org.dataloader.stats.StatisticsCollector;
 import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
 import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -13,9 +16,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -200,5 +205,117 @@ public class DataLoaderStatsTest {
         assertThat(stats.getBatchLoadCount(), equalTo(6L));
         assertThat(stats.getBatchLoadExceptionCount(), equalTo(2L));
         assertThat(stats.getLoadErrorCount(), equalTo(3L));
+    }
+
+    /**
+     * A simple {@link StatisticsCollector} that stores the contexts passed to it.
+     */
+    private static class ContextPassingStatisticsCollector implements StatisticsCollector {
+
+        public List<IncrementLoadCountStatisticsContext<?>> incrementLoadCountStatisticsContexts = new ArrayList<>();
+        public List<IncrementLoadErrorCountStatisticsContext<?>> incrementLoadErrorCountStatisticsContexts = new ArrayList<>();
+        public List<IncrementBatchLoadCountByStatisticsContext<?>> incrementBatchLoadCountByStatisticsContexts = new ArrayList<>();
+        public List<IncrementBatchLoadExceptionCountStatisticsContext<?>> incrementBatchLoadExceptionCountStatisticsContexts = new ArrayList<>();
+        public List<IncrementCacheHitCountStatisticsContext<?>> incrementCacheHitCountStatisticsContexts = new ArrayList<>();
+
+        @Override
+        public <K> long incrementLoadCount(IncrementLoadCountStatisticsContext<K> context) {
+            incrementLoadCountStatisticsContexts.add(context);
+            return 0;
+        }
+
+        @Deprecated
+        @Override
+        public long incrementLoadCount() {
+            return 0;
+        }
+
+        @Override
+        public <K> long incrementLoadErrorCount(IncrementLoadErrorCountStatisticsContext<K> context) {
+            incrementLoadErrorCountStatisticsContexts.add(context);
+            return 0;
+        }
+
+        @Deprecated
+        @Override
+        public long incrementLoadErrorCount() {
+            return 0;
+        }
+
+        @Override
+        public <K> long incrementBatchLoadCountBy(long delta, IncrementBatchLoadCountByStatisticsContext<K> context) {
+            incrementBatchLoadCountByStatisticsContexts.add(context);
+            return 0;
+        }
+
+        @Deprecated
+        @Override
+        public long incrementBatchLoadCountBy(long delta) {
+            return 0;
+        }
+
+        @Override
+        public <K> long incrementBatchLoadExceptionCount(IncrementBatchLoadExceptionCountStatisticsContext<K> context) {
+            incrementBatchLoadExceptionCountStatisticsContexts.add(context);
+            return 0;
+        }
+
+        @Deprecated
+        @Override
+        public long incrementBatchLoadExceptionCount() {
+            return 0;
+        }
+
+        @Override
+        public <K> long incrementCacheHitCount(IncrementCacheHitCountStatisticsContext<K> context) {
+            incrementCacheHitCountStatisticsContexts.add(context);
+            return 0;
+        }
+
+        @Deprecated
+        @Override
+        public long incrementCacheHitCount() {
+            return 0;
+        }
+
+        @Override
+        public Statistics getStatistics() {
+            return null;
+        }
+    }
+
+    @Test
+    public void context_is_passed_through_to_collector() {
+        ContextPassingStatisticsCollector statisticsCollector = new ContextPassingStatisticsCollector();
+        DataLoader<String, Try<String>> loader = newDataLoader(batchLoaderThatBlows,
+                DataLoaderOptions.newOptions().setStatisticsCollector(() -> statisticsCollector)
+        );
+
+        loader.load("key", "keyContext");
+        assertThat(statisticsCollector.incrementLoadCountStatisticsContexts, hasSize(1));
+        assertThat(statisticsCollector.incrementLoadCountStatisticsContexts.get(0).getKey(), equalTo("key"));
+        assertThat(statisticsCollector.incrementLoadCountStatisticsContexts.get(0).getCallContext(), equalTo("keyContext"));
+
+        loader.load("key", "keyContext");
+        assertThat(statisticsCollector.incrementCacheHitCountStatisticsContexts, hasSize(1));
+        assertThat(statisticsCollector.incrementCacheHitCountStatisticsContexts.get(0).getKey(), equalTo("key"));
+        assertThat(statisticsCollector.incrementCacheHitCountStatisticsContexts.get(0).getCallContext(), equalTo("keyContext"));
+
+        loader.dispatch();
+        assertThat(statisticsCollector.incrementBatchLoadCountByStatisticsContexts, hasSize(1));
+        assertThat(statisticsCollector.incrementBatchLoadCountByStatisticsContexts.get(0).getKeys(), equalTo(singletonList("key")));
+        assertThat(statisticsCollector.incrementBatchLoadCountByStatisticsContexts.get(0).getCallContexts(), equalTo(singletonList("keyContext")));
+
+        loader.load("exception", "exceptionKeyContext");
+        loader.dispatch();
+        assertThat(statisticsCollector.incrementBatchLoadExceptionCountStatisticsContexts, hasSize(1));
+        assertThat(statisticsCollector.incrementBatchLoadExceptionCountStatisticsContexts.get(0).getKeys(), equalTo(singletonList("exception")));
+        assertThat(statisticsCollector.incrementBatchLoadExceptionCountStatisticsContexts.get(0).getCallContexts(), equalTo(singletonList("exceptionKeyContext")));
+
+        loader.load("error", "errorKeyContext");
+        loader.dispatch();
+        assertThat(statisticsCollector.incrementLoadErrorCountStatisticsContexts, hasSize(1));
+        assertThat(statisticsCollector.incrementLoadErrorCountStatisticsContexts.get(0).getKey(), equalTo("error"));
+        assertThat(statisticsCollector.incrementLoadErrorCountStatisticsContexts.get(0).getCallContext(), equalTo("errorKeyContext"));
     }
 }

--- a/src/test/java/org/dataloader/stats/StatisticsCollectorTest.java
+++ b/src/test/java/org/dataloader/stats/StatisticsCollectorTest.java
@@ -1,9 +1,15 @@
 package org.dataloader.stats;
 
+import org.dataloader.stats.context.IncrementBatchLoadCountByStatisticsContext;
+import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsContext;
+import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
+import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -21,11 +27,11 @@ public class StatisticsCollectorTest {
         assertThat(collector.getStatistics().getLoadErrorCount(), equalTo(0L));
 
 
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
-        collector.incrementCacheHitCount();
-        collector.incrementBatchLoadExceptionCount();
-        collector.incrementLoadErrorCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(singletonList(1), singletonList(null)));
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
 
         assertThat(collector.getStatistics().getLoadCount(), equalTo(1L));
         assertThat(collector.getStatistics().getBatchLoadCount(), equalTo(1L));
@@ -40,46 +46,46 @@ public class StatisticsCollectorTest {
 
         StatisticsCollector collector = new SimpleStatisticsCollector();
 
-        collector.incrementLoadCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
 
         Statistics stats = collector.getStatistics();
         assertThat(stats.getBatchLoadRatio(), equalTo(0d));
         assertThat(stats.getCacheHitRatio(), equalTo(0d));
 
 
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
 
         stats = collector.getStatistics();
         assertThat(stats.getBatchLoadRatio(), equalTo(1d / 4d));
 
 
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementCacheHitCount();
-        collector.incrementCacheHitCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
 
         stats = collector.getStatistics();
         assertThat(stats.getCacheHitRatio(), equalTo(2d / 7d));
 
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadExceptionCount();
-        collector.incrementBatchLoadExceptionCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(singletonList(1), singletonList(null)));
+        collector.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(singletonList(1), singletonList(null)));
 
         stats = collector.getStatistics();
         assertThat(stats.getBatchLoadExceptionRatio(), equalTo(2d / 10d));
 
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementLoadCount();
-        collector.incrementLoadErrorCount();
-        collector.incrementLoadErrorCount();
-        collector.incrementLoadErrorCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
 
         stats = collector.getStatistics();
         assertThat(stats.getLoadErrorRatio(), equalTo(3d / 13d));
@@ -95,9 +101,9 @@ public class StatisticsCollectorTest {
         assertThat(collector.getStatistics().getCacheHitCount(), equalTo(0L));
 
 
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
-        collector.incrementCacheHitCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
 
         assertThat(collector.getStatistics().getLoadCount(), equalTo(1L));
         assertThat(collector.getStatistics().getBatchLoadCount(), equalTo(1L));
@@ -109,9 +115,9 @@ public class StatisticsCollectorTest {
 
         CompletableFuture.supplyAsync(() -> {
 
-            collector.incrementLoadCount();
-            collector.incrementBatchLoadCountBy(1);
-            collector.incrementCacheHitCount();
+            collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+            collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+            collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
 
             // per thread stats here
             assertThat(collector.getStatistics().getLoadCount(), equalTo(1L));
@@ -128,9 +134,9 @@ public class StatisticsCollectorTest {
 
         // back on this main thread
 
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
-        collector.incrementCacheHitCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
 
         // per thread stats here
         assertThat(collector.getStatistics().getLoadCount(), equalTo(2L));
@@ -168,11 +174,11 @@ public class StatisticsCollectorTest {
         assertThat(collector.getStatistics().getCacheMissCount(), equalTo(0L));
 
 
-        collector.incrementLoadCount();
-        collector.incrementBatchLoadCountBy(1);
-        collector.incrementCacheHitCount();
-        collector.incrementBatchLoadExceptionCount();
-        collector.incrementLoadErrorCount();
+        collector.incrementLoadCount(new IncrementLoadCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(singletonList(1), singletonList(null)));
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
 
         assertThat(collector.getStatistics().getLoadCount(), equalTo(1L));
         assertThat(collector.getStatistics().getBatchLoadCount(), equalTo(1L));
@@ -199,10 +205,10 @@ public class StatisticsCollectorTest {
     @Test
     public void noop_is_just_that() throws Exception {
         StatisticsCollector collector = new NoOpStatisticsCollector();
-        collector.incrementLoadErrorCount();
-        collector.incrementBatchLoadExceptionCount();
-        collector.incrementBatchLoadCountBy(1);
-        collector.incrementCacheHitCount();
+        collector.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(1, null));
+        collector.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(singletonList(1), singletonList(null)));
+        collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
+        collector.incrementCacheHitCount(new IncrementCacheHitCountStatisticsContext<>(1, null));
 
         assertThat(collector.getStatistics().getLoadCount(), equalTo(0L));
         assertThat(collector.getStatistics().getBatchLoadCount(), equalTo(0L));


### PR DESCRIPTION
The `StatisticsCollector` interface is useful for gathering basic
metrics about data loaders, but is limited in that we are unable to pass
in any sort of context (key or call). This would allow us to obtain more
insightful metrics (for example, we would be able to break down metrics
based on the GraphQL operation name).

To this end, we add `*StatisticsContext` objects to each
`StatisticsCollector` method; we provide distinct implementations for
each one rather than a generic catch-all so that we may evolve them
independently as needed.