### PR TITLE
Prepend 0.0.0 to build version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    def version = new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
+    def version = "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
     println "created development version: $version"
     version
 }


### PR DESCRIPTION
Adding this so build versions do not appear as the "latest" release on Maven, when sorting in descending order