### PR TITLE
Predicates in DataLoaders

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -18,6 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicApi;
 import org.dataloader.impl.Assertions;
+import org.dataloader.registries.DispatchPredicate;
 import org.dataloader.stats.NoOpStatisticsCollector;
 import org.dataloader.stats.StatisticsCollector;
 
@@ -42,6 +43,7 @@ public class DataLoaderOptions {
     private CacheKey<?> cacheKeyFunction;
     private CacheMap<?, ?> cacheMap;
     private ValueCache<?, ?> valueCache;
+    private DispatchPredicate dispatchPredicate;
     private int maxBatchSize;
     private Supplier<StatisticsCollector> statisticsCollector;
     private BatchLoaderContextProvider environmentProvider;
@@ -58,6 +60,7 @@ public class DataLoaderOptions {
         statisticsCollector = NoOpStatisticsCollector::new;
         environmentProvider = NULL_PROVIDER;
         valueCacheOptions = ValueCacheOptions.newOptions();
+        dispatchPredicate = DispatchPredicate.dispatchAlways();
     }
 
     /**
@@ -283,6 +286,25 @@ public class DataLoaderOptions {
      */
     public DataLoaderOptions setValueCache(ValueCache<?, ?> valueCache) {
         this.valueCache = valueCache;
+        return this;
+    }
+
+    /**
+     * @return the dispatch predicate of these options
+     */
+    public DispatchPredicate getDispatchPredicate() {
+        return dispatchPredicate;
+    }
+
+    /**
+     * Sets the {@link DispatchPredicate} to use for.
+     *
+     * @param dispatchPredicate the non-null DispatchPredicate to use
+     *
+     * @return the data loader options for fluent coding
+     */
+    public DataLoaderOptions dispatchPredicate(DispatchPredicate dispatchPredicate) {
+        this.dispatchPredicate = nonNull(dispatchPredicate);
         return this;
     }
 

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -297,9 +297,9 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets the {@link DispatchPredicate} to use for.
+     * Sets the {@link DispatchPredicate} to use.
      *
-     * @param dispatchPredicate the non-null DispatchPredicate to use
+     * @param dispatchPredicate a non-null DispatchPredicate to use
      *
      * @return the data loader options for fluent coding
      */

--- a/src/main/java/org/dataloader/DispatchResult.java
+++ b/src/main/java/org/dataloader/DispatchResult.java
@@ -15,10 +15,16 @@ import java.util.concurrent.CompletableFuture;
 public class DispatchResult<T> {
     private final CompletableFuture<List<T>> futureList;
     private final int keysCount;
+    private final boolean wasDispatched;
 
     public DispatchResult(CompletableFuture<List<T>> futureList, int keysCount) {
+        this(futureList, keysCount, true);
+    }
+
+    public DispatchResult(CompletableFuture<List<T>> futureList, int keysCount, boolean wasDispatched) {
         this.futureList = futureList;
         this.keysCount = keysCount;
+        this.wasDispatched = wasDispatched;
     }
 
     public CompletableFuture<List<T>> getPromisedResults() {
@@ -27,5 +33,15 @@ public class DispatchResult<T> {
 
     public int getKeysCount() {
         return keysCount;
+    }
+
+    /**
+     * If the {@link org.dataloader.registries.DispatchPredicate} associated with the dataloader
+     * returns false, then the call to dispatch was not performed and this will return false.
+     *
+     * @return true of the dispatch call was actually made or false if it was not
+     */
+    public boolean wasDispatched() {
+        return wasDispatched;
     }
 }

--- a/src/main/java/org/dataloader/DispatchResult.java
+++ b/src/main/java/org/dataloader/DispatchResult.java
@@ -38,6 +38,8 @@ public class DispatchResult<T> {
     /**
      * If the {@link org.dataloader.registries.DispatchPredicate} associated with the dataloader
      * returns false, then the call to dispatch was not performed and this will return false.
+     * <p>
+     * Similarly, if the set the loaded keys was empty or the batching is not enabled them this will return  false
      *
      * @return true of the dispatch call was actually made or false if it was not
      */

--- a/src/main/java/org/dataloader/registries/DispatchPredicate.java
+++ b/src/main/java/org/dataloader/registries/DispatchPredicate.java
@@ -6,14 +6,16 @@ import java.time.Duration;
 import java.util.Objects;
 
 /**
- * A predicate class used by {@link ScheduledDataLoaderRegistry} to decide whether to dispatch or not
+ * A predicate class used by {@link ScheduledDataLoaderRegistry}s as well as by individual
+ * {@link DataLoader}s to decide whether to dispatch or not.
  */
 @FunctionalInterface
 public interface DispatchPredicate {
     /**
-     * This predicate tests whether the data loader should be dispatched or not.
+     * This predicate tests whether the data loader should be dispatched or not.  If the predicate is associated direct to a {@link DataLoader}
+     * then the dataLoaderKey parameter will be null.
      *
-     * @param dataLoaderKey the key of the data loader when registered
+     * @param dataLoaderKey the key of the data loader when registered or null if this is a predicate associated direct with a {@link DataLoader}
      * @param dataLoader    the dataloader to dispatch
      *
      * @return true if the data loader SHOULD be dispatched
@@ -68,7 +70,7 @@ public interface DispatchPredicate {
      *
      * @param duration the length of time to check
      *
-     * @return true if the data loader has not been dispatched in duration time
+     * @return a predicate that returns true if the data loader has not been dispatched in duration time
      */
     static DispatchPredicate dispatchIfLongerThan(Duration duration) {
         return (dataLoaderKey, dataLoader) -> {
@@ -79,14 +81,32 @@ public interface DispatchPredicate {
 
     /**
      * This predicate will return true if the {@link DataLoader#dispatchDepth()} is greater than the specified depth.
-     *
+     * <p>
      * This will act as minimum batch size.  There must be more than `depth` items queued for the predicate to return true.
      *
      * @param depth the value to be greater than
      *
-     * @return true if the {@link DataLoader#dispatchDepth()} is greater than the specified depth.
+     * @return a predicate that returns true if the {@link DataLoader#dispatchDepth()} is greater than the specified depth.
      */
     static DispatchPredicate dispatchIfDepthGreaterThan(int depth) {
         return (dataLoaderKey, dataLoader) -> dataLoader.dispatchDepth() > depth;
+    }
+
+    /**
+     * This predicate will return true always
+     *
+     * @return a predicate that returns true always
+     */
+    static DispatchPredicate dispatchAlways() {
+        return (dataLoaderKey, dataLoader) -> true;
+    }
+
+    /**
+     * This predicate will never return true
+     *
+     * @return a predicate that never returns true
+     */
+    static DispatchPredicate dispatchNever() {
+        return (dataLoaderKey, dataLoader) -> false;
     }
 }

--- a/src/test/java/org/dataloader/DataLoaderPredicateTest.java
+++ b/src/test/java/org/dataloader/DataLoaderPredicateTest.java
@@ -1,0 +1,119 @@
+package org.dataloader;
+
+import org.dataloader.registries.DispatchPredicate;
+import org.dataloader.stats.SimpleStatisticsCollector;
+import org.dataloader.stats.Statistics;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Arrays.asList;
+import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests related to dispatching predicates.
+ */
+public class DataLoaderPredicateTest {
+
+    @Test
+    public void the_predicate_will_prevent_loading() {
+        BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
+        DataLoader<String, String> loader = newDataLoader(batchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                        .dispatchPredicate(DispatchPredicate.dispatchNever())
+        );
+
+        loader.load("A");
+        loader.load("B");
+        loader.loadMany(asList("C", "D"));
+
+        Statistics stats = loader.getStatistics();
+        assertThat(stats.getLoadCount(), equalTo(4L));
+        assertThat(stats.getBatchInvokeCount(), equalTo(0L));
+        assertThat(stats.getBatchLoadCount(), equalTo(0L));
+        assertThat(stats.getCacheHitCount(), equalTo(0L));
+
+        DispatchResult<String> dispatchResult = loader.dispatchWithCounts();
+        assertThat(dispatchResult.wasDispatched(), equalTo(false));
+        assertThat(dispatchResult.getKeysCount(), equalTo(4));
+
+        stats = loader.getStatistics();
+        assertThat(stats.getLoadCount(), equalTo(4L));
+        assertThat(stats.getBatchInvokeCount(), equalTo(0L));
+        assertThat(stats.getBatchLoadCount(), equalTo(0L));
+
+
+        loader.load("A");
+        loader.load("B");
+
+        dispatchResult = loader.dispatchWithCounts();
+        assertThat(dispatchResult.wasDispatched(), equalTo(false));
+        assertThat(dispatchResult.getKeysCount(), equalTo(4));
+
+        stats = loader.getStatistics();
+        assertThat(stats.getLoadCount(), equalTo(6L));
+        assertThat(stats.getBatchInvokeCount(), equalTo(0L));
+        assertThat(stats.getBatchLoadCount(), equalTo(0L));
+    }
+
+    @Test
+    public void the_predicate_will_allow_loading_by_default() {
+        BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
+        DataLoader<String, String> loader = newDataLoader(batchLoader,
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                        .dispatchPredicate(DispatchPredicate.dispatchAlways())
+        );
+
+        loader.load("A");
+        loader.load("B");
+        loader.loadMany(asList("C", "D"));
+
+
+        DispatchResult<String> dispatchResult = loader.dispatchWithCounts();
+        assertThat(dispatchResult.wasDispatched(), equalTo(true));
+        assertThat(dispatchResult.getKeysCount(), equalTo(4));
+
+        Statistics stats = loader.getStatistics();
+        assertThat(stats.getLoadCount(), equalTo(4L));
+        assertThat(stats.getBatchInvokeCount(), equalTo(1L));
+        assertThat(stats.getBatchLoadCount(), equalTo(4L));
+
+
+        loader.load("E");
+        loader.load("F");
+
+        dispatchResult = loader.dispatchWithCounts();
+        assertThat(dispatchResult.wasDispatched(), equalTo(true));
+        assertThat(dispatchResult.getKeysCount(), equalTo(2));
+
+        stats = loader.getStatistics();
+        assertThat(stats.getLoadCount(), equalTo(6L));
+        assertThat(stats.getBatchInvokeCount(), equalTo(2L));
+        assertThat(stats.getBatchLoadCount(), equalTo(6L));
+    }
+
+    @Test
+    public void dataloader_options_have_a_default_which_is_always_on() {
+        BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
+        DataLoaderOptions dataLoaderOptions = DataLoaderOptions.newOptions();
+
+        DispatchPredicate defaultPredicate = dataLoaderOptions.getDispatchPredicate();
+        assertThat(defaultPredicate, notNullValue());
+        assertThat(defaultPredicate.test(null, null), equalTo(true));
+
+
+        DataLoader<String, String> loader = newDataLoader(batchLoader, dataLoaderOptions);
+
+        loader.load("A");
+        loader.load("B");
+        loader.loadMany(asList("C", "D"));
+
+        DispatchResult<String> dispatchResult = loader.dispatchWithCounts();
+        assertThat(dispatchResult.wasDispatched(), equalTo(true));
+        assertThat(dispatchResult.getKeysCount(), equalTo(4));
+
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/graphql-java/java-dataloader/discussions/125

This allows for `DataLoader`s to have a individual predicates associated with them

The one thing the irks me is that 

* `org.dataloader.registries.DispatchPredicate` reside in a different package
* `boolean test(String dataLoaderKey, DataLoader<?, ?> dataLoader)` takes a dataLoaderKey but this only applies in the registry case

However introducing a new `DispatchPredicate` elsewhere that is basically exactly the same irks me as well.

