### PR TITLE
Ticker mode on ScheduledDataLoaderRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,26 @@ You will want to look at sharing the `ScheduledExecutorService` in some way betw
 otherwise you will be creating a thread per `ScheduledDataLoaderRegistry` instance created and with enough concurrent requests
 you may create too many threads.
 
+### ScheduledDataLoaderRegistry dispatching algorithm
+
+When ticker mode is **false** the `ScheduledDataLoaderRegistry` algorithm is as follows :
+
+* Nothing starts scheduled - some code must call `registry.dispatchAll()` a first time
+* Then for every `DataLoader` in the registry
+  * The `DispatchPredicate` is called to test if the data loader should be dispatched
+    * if it returns **false** then a task is scheduled to re-evaluate this specific dataloader in the near future 
+    * If it returns **true**, then `dataLoader.dispatch()` is called and the dataloader is not rescheduled again
+* The re-evaluation tasks are run periodically according to the `registry.getScheduleDuration()`
+
+When ticker mode is **true** the `ScheduledDataLoaderRegistry` algorithm is as follows:
+
+* Nothing starts scheduled - some code must call `registry.dispatchAll()` a first time
+* Then for every `DataLoader` in the registry
+    * The `DispatchPredicate` is called to test if the data loader should be dispatched
+        * if it returns **false** then a task is scheduled to re-evaluate this specific dataloader in the near future
+        * If it returns **true**, then `dataLoader.dispatch()` is called **and** a task is scheduled to re-evaluate this specific dataloader in the near future
+* The re-evaluation tasks are run periodically according to the `registry.getScheduleDuration()`
+
 ## Other information sources
 
 - [Facebook DataLoader Github repo](https://github.com/facebook/dataloader)

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -42,7 +42,8 @@ import static org.dataloader.impl.Assertions.nonNull;
  * <p>
  * When {@link #tickerMode} is true, you really SHOULD close the registry say at the end of a request otherwise you will leave a job
  * on the {@link ScheduledExecutorService} that is continuously dispatching.
- * <p> * If you wanted to create a ScheduledDataLoaderRegistry that started a rescheduling immediately, just create one and
+ * <p>
+ * If you wanted to create a ScheduledDataLoaderRegistry that started a rescheduling immediately, just create one and
  * call {@link #rescheduleNow()}.
  * <p>
  * By default, it uses a {@link Executors#newSingleThreadScheduledExecutor()}} to schedule the tasks.  However, if you

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -157,25 +157,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         return this;
     }
 
-    /**
-     * Returns true if the dataloader has a predicate which returned true, OR the overall
-     * registry predicate returned true.
-     *
-     * @param dataLoaderKey the key in the dataloader map
-     * @param dataLoader    the dataloader
-     *
-     * @return true if it should dispatch
-     */
-    private boolean shouldDispatch(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
-        DispatchPredicate dispatchPredicate = dataLoaderPredicates.get(dataLoader);
-        if (dispatchPredicate != null) {
-            if (dispatchPredicate.test(dataLoaderKey, dataLoader)) {
-                return true;
-            }
-        }
-        return this.dispatchPredicate.test(dataLoaderKey, dataLoader);
-    }
-
     @Override
     public void dispatchAll() {
         dispatchAllWithCount();
@@ -220,6 +201,25 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      */
     public void rescheduleNow() {
         dataLoaders.forEach(this::reschedule);
+    }
+
+    /**
+     * Returns true if the dataloader has a predicate which returned true, OR the overall
+     * registry predicate returned true.
+     *
+     * @param dataLoaderKey the key in the dataloader map
+     * @param dataLoader    the dataloader
+     *
+     * @return true if it should dispatch
+     */
+    private boolean shouldDispatch(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
+        DispatchPredicate dispatchPredicate = dataLoaderPredicates.get(dataLoader);
+        if (dispatchPredicate != null) {
+            if (dispatchPredicate.test(dataLoaderKey, dataLoader)) {
+                return true;
+            }
+        }
+        return this.dispatchPredicate.test(dataLoaderKey, dataLoader);
     }
 
     private void reschedule(String key, DataLoader<?, ?> dataLoader) {

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -96,7 +96,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         for (Map.Entry<String, DataLoader<?, ?>> entry : dataLoaders.entrySet()) {
             DataLoader<?, ?> dataLoader = entry.getValue();
             String key = entry.getKey();
-            dispatchOrReschedule(key, dataLoader);
+            sum += dispatchOrReschedule(key, dataLoader);
         }
         return sum;
     }
@@ -134,14 +134,16 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         }
     }
 
-    private void dispatchOrReschedule(String key, DataLoader<?, ?> dataLoader) {
+    private int dispatchOrReschedule(String key, DataLoader<?, ?> dataLoader) {
+        int sum = 0;
         boolean shouldDispatch = dispatchPredicate.test(key, dataLoader);
         if (shouldDispatch) {
-            dataLoader.dispatch();
+            sum = dataLoader.dispatchWithCounts().getKeysCount();
         }
         if (tickerMode || !shouldDispatch) {
             reschedule(key, dataLoader);
         }
+        return sum;
     }
 
     /**

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -15,14 +15,33 @@ import static org.dataloader.impl.Assertions.nonNull;
 
 /**
  * This {@link DataLoaderRegistry} will use a {@link DispatchPredicate} when {@link #dispatchAll()} is called
- * to test (for each {@link DataLoader} in the registry) if a dispatch should proceed.  If the predicate returns false, then a task is scheduled
- * to perform that predicate dispatch again via the {@link ScheduledExecutorService}.
+ * to test (for each {@link DataLoader} in the registry) if a dispatch should proceed.  If the predicate returns false,
+ * then a task is scheduled to perform that predicate dispatch again via the {@link ScheduledExecutorService}.
  * <p>
- * This will continue to loop (test false and reschedule) until such time as the predicate returns true, in which case
- * no rescheduling will occur and you will need to call dispatch again to restart the process.
+ * In the default mode, when {@link #tickerMode} is false, the registry will continue to loop (test false and reschedule) until such time as the predicate returns true, in which case
+ * no rescheduling will occur, and you will need to call dispatch again to restart the process.
+ * <p>
+ * However, when {@link #tickerMode} is true, the registry will always reschedule continuously after the first ever call to {@link #dispatchAll()}.
+ * <p>
+ * This will allow you to chain together {@link DataLoader} load calls like this :
+ * <pre>{@code
+ *   CompletableFuture<String> future = dataLoaderA.load("A")
+ *                                          .thenCompose(value -> dataLoaderB.load(value));
+ * }</pre>
+ * <p>
+ * However, it may mean your batching will not be as efficient as it might be. In environments
+ * like graphql this might mean you are too eager in fetching.  The {@link DispatchPredicate} still runs to decide if
+ * dispatch should happen however in ticker mode it will be continuously rescheduled.
+ * <p>
+ * When {@link #tickerMode} is true, you really SHOULD close the registry say at the end of a request otherwise you will leave a job
+ * on the {@link ScheduledExecutorService} that is continuously dispatching.
  * <p>
  * If you wanted to create a ScheduledDataLoaderRegistry that started a rescheduling immediately, just create one and
  * call {@link #rescheduleNow()}.
+ * <p>
+ * By default, it uses a {@link Executors#newSingleThreadScheduledExecutor()}} to schedule the tasks.  However, if you
+ * are creating a {@link ScheduledDataLoaderRegistry} per request you will want to look at sharing this {@link ScheduledExecutorService}
+ * to avoid creating a new thread per registry created.
  * <p>
  * This code is currently marked as {@link ExperimentalApi}
  */
@@ -32,6 +51,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     private final ScheduledExecutorService scheduledExecutorService;
     private final DispatchPredicate dispatchPredicate;
     private final Duration schedule;
+    private final boolean tickerMode;
     private volatile boolean closed;
 
     private ScheduledDataLoaderRegistry(Builder builder) {
@@ -39,6 +59,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         this.scheduledExecutorService = builder.scheduledExecutorService;
         this.dispatchPredicate = builder.dispatchPredicate;
         this.schedule = builder.schedule;
+        this.tickerMode = builder.tickerMode;
         this.closed = false;
     }
 
@@ -57,6 +78,13 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         return schedule;
     }
 
+    /**
+     * @return true of the registry is in ticker mode or false otherwise
+     */
+    public boolean isTickerMode() {
+        return tickerMode;
+    }
+
     @Override
     public void dispatchAll() {
         dispatchAllWithCount();
@@ -68,11 +96,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         for (Map.Entry<String, DataLoader<?, ?>> entry : dataLoaders.entrySet()) {
             DataLoader<?, ?> dataLoader = entry.getValue();
             String key = entry.getKey();
-            if (dispatchPredicate.test(key, dataLoader)) {
-                sum += dataLoader.dispatchWithCounts().getKeysCount();
-            } else {
-                reschedule(key, dataLoader);
-            }
+            dispatchOrReschedule(key, dataLoader);
         }
         return sum;
     }
@@ -111,9 +135,11 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     }
 
     private void dispatchOrReschedule(String key, DataLoader<?, ?> dataLoader) {
-        if (dispatchPredicate.test(key, dataLoader)) {
+        boolean shouldDispatch = dispatchPredicate.test(key, dataLoader);
+        if (shouldDispatch) {
             dataLoader.dispatch();
-        } else {
+        }
+        if (tickerMode || !shouldDispatch) {
             reschedule(key, dataLoader);
         }
     }
@@ -134,6 +160,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         private DispatchPredicate dispatchPredicate = (key, dl) -> true;
         private Duration schedule = Duration.ofMillis(10);
         private final Map<String, DataLoader<?, ?>> dataLoaders = new HashMap<>();
+        private boolean tickerMode = false;
 
         public Builder scheduledExecutorService(ScheduledExecutorService executorService) {
             this.scheduledExecutorService = nonNull(executorService);
@@ -173,6 +200,20 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          */
         public Builder registerAll(DataLoaderRegistry otherRegistry) {
             dataLoaders.putAll(otherRegistry.getDataLoadersMap());
+            return this;
+        }
+
+        /**
+         * This sets ticker mode on the registry.  When ticker mode is true the registry will
+         * continuously reschedule the data loaders for possible dispatching after the first call
+         * to dispatchAll.
+         *
+         * @param tickerMode true or false
+         *
+         * @return this builder for a fluent pattern
+         */
+        public Builder tickerMode(boolean tickerMode) {
+            this.tickerMode = tickerMode;
             return this;
         }
 

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -18,11 +18,14 @@ import org.dataloader.stats.ThreadLocalStatisticsCollector;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -278,7 +281,7 @@ public class ReadmeExamples {
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 
-    private void ScheduledDispatche() {
+    private void ScheduledDispatcher() {
         DispatchPredicate depthOrTimePredicate = DispatchPredicate.dispatchIfDepthGreaterThan(10)
                 .or(DispatchPredicate.dispatchIfLongerThan(Duration.ofMillis(200)));
 
@@ -287,5 +290,36 @@ public class ReadmeExamples {
                 .schedule(Duration.ofMillis(10))
                 .register("users", userDataLoader)
                 .build();
+    }
+
+
+    DataLoader<String, User> dataLoaderA = DataLoaderFactory.newDataLoader(userBatchLoader);
+    DataLoader<User, Object> dataLoaderB = DataLoaderFactory.newDataLoader(keys -> {
+        return CompletableFuture.completedFuture(Collections.singletonList(1L));
+    });
+
+    private void ScheduledDispatcherChained() {
+        CompletableFuture<Object> chainedCalls = dataLoaderA.load("user1")
+                .thenCompose(userAsKey -> dataLoaderB.load(userAsKey));
+
+
+        CompletableFuture<Object> chainedWithImmediateDispatch = dataLoaderA.load("user1")
+                .thenCompose(userAsKey -> {
+                    CompletableFuture<Object> loadB = dataLoaderB.load(userAsKey);
+                    dataLoaderB.dispatch();
+                    return loadB;
+                });
+
+
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+        ScheduledDataLoaderRegistry registry = ScheduledDataLoaderRegistry.newScheduledRegistry()
+                .register("a", dataLoaderA)
+                .register("b", dataLoaderB)
+                .scheduledExecutorService(executorService)
+                .schedule(Duration.ofMillis(10))
+                .tickerMode(true) // ticker mode is on
+                .build();
+
     }
 }

--- a/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryTest.java
@@ -284,7 +284,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
 
         assertThat(registry.isTickerMode(), equalTo(true));
 
-        registry.dispatchAll();
+        int count = registry.dispatchAllWithCount();
+        assertThat(count,equalTo(1));
 
         await().atMost(TWO_SECONDS).untilAtomic(done, is(true));
 
@@ -312,7 +313,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
 
         assertThat(registry.isTickerMode(), equalTo(false));
 
-        registry.dispatchAll();
+        int count = registry.dispatchAllWithCount();
+        assertThat(count,equalTo(1));
 
         try {
             await().atMost(TWO_SECONDS).untilAtomic(done, is(true));


### PR DESCRIPTION
This creates a ticker mode where by calls to the dataloaders will always be rescheduled after the first `.dispatch()` call is made

Read the readme and javadoc in the PR for all gory details