### PR TITLE
Adds a predicate to DataLoaderRegistry and a per dataloader map of pedicates is also possible

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/DataLoaderRegistry.java
@@ -25,7 +25,7 @@ public class DataLoaderRegistry {
     public DataLoaderRegistry() {
     }
 
-    protected DataLoaderRegistry(Builder<?> builder) {
+    private DataLoaderRegistry(Builder builder) {
         this.dataLoaders.putAll(builder.dataLoaders);
     }
 
@@ -179,14 +179,9 @@ public class DataLoaderRegistry {
         return new Builder();
     }
 
-    public static class Builder<B extends Builder<B>> {
+    public static class Builder {
 
         private final Map<String, DataLoader<?, ?>> dataLoaders = new HashMap<>();
-
-        protected B self() {
-            //noinspection unchecked
-            return (B) this;
-        }
 
         /**
          * This will register a new dataloader
@@ -196,9 +191,9 @@ public class DataLoaderRegistry {
          *
          * @return this builder for a fluent pattern
          */
-        public B register(String key, DataLoader<?, ?> dataLoader) {
+        public Builder register(String key, DataLoader<?, ?> dataLoader) {
             dataLoaders.put(key, dataLoader);
-            return self();
+            return this;
         }
 
         /**
@@ -209,9 +204,9 @@ public class DataLoaderRegistry {
          *
          * @return this builder for a fluent pattern
          */
-        public B registerAll(DataLoaderRegistry otherRegistry) {
+        public Builder registerAll(DataLoaderRegistry otherRegistry) {
             dataLoaders.putAll(otherRegistry.dataLoaders);
-            return self();
+            return this;
         }
 
         /**

--- a/src/main/java/org/dataloader/annotations/GuardedBy.java
+++ b/src/main/java/org/dataloader/annotations/GuardedBy.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 public @interface GuardedBy {
 
   /**
-   * The lock that should be held.
+   * @return The lock that should be held.
    */
   String value();
 }

--- a/src/main/java/org/dataloader/registries/DispatchPredicate.java
+++ b/src/main/java/org/dataloader/registries/DispatchPredicate.java
@@ -18,7 +18,7 @@ public interface DispatchPredicate {
     /**
      * A predicate that always returns false
      */
-    DispatchPredicate DISPATCH_NEVER = (dataLoaderKey, dataLoader) -> true;
+    DispatchPredicate DISPATCH_NEVER = (dataLoaderKey, dataLoader) -> false;
 
     /**
      * This predicate tests whether the data loader should be dispatched or not.

--- a/src/main/java/org/dataloader/registries/DispatchPredicate.java
+++ b/src/main/java/org/dataloader/registries/DispatchPredicate.java
@@ -10,6 +10,16 @@ import java.util.Objects;
  */
 @FunctionalInterface
 public interface DispatchPredicate {
+
+    /**
+     * A predicate that always returns true
+     */
+    DispatchPredicate DISPATCH_ALWAYS = (dataLoaderKey, dataLoader) -> true;
+    /**
+     * A predicate that always returns false
+     */
+    DispatchPredicate DISPATCH_NEVER = (dataLoaderKey, dataLoader) -> true;
+
     /**
      * This predicate tests whether the data loader should be dispatched or not.
      *

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -15,12 +15,15 @@ import java.util.concurrent.TimeUnit;
 import static org.dataloader.impl.Assertions.nonNull;
 
 /**
- * This {@link DataLoaderRegistry} will use a {@link DispatchPredicate} when {@link #dispatchAll()} is called
+ * This {@link DataLoaderRegistry} will use {@link DispatchPredicate}s when {@link #dispatchAll()} is called
  * to test (for each {@link DataLoader} in the registry) if a dispatch should proceed.  If the predicate returns false, then a task is scheduled
  * to perform that predicate dispatch again via the {@link ScheduledExecutorService}.
  * <p>
+ * It;s possible to have a {@link DispatchPredicate} per dataloader as well as a default {@link DispatchPredicate} for the
+ * whole {@link ScheduledDataLoaderRegistry}.
+ * <p>
  * This will continue to loop (test false and reschedule) until such time as the predicate returns true, in which case
- * no rescheduling will occur and you will need to call dispatch again to restart the process.
+ * no rescheduling will occur, and you will need to call dispatch again to restart the process.
  * <p>
  * If you wanted to create a ScheduledDataLoaderRegistry that started a rescheduling immediately, just create one and
  * call {@link #rescheduleNow()}.
@@ -94,17 +97,19 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     }
 
     /**
-     * @return the current dispatch predicate
-     */
-    public DispatchPredicate getDispatchPredicate() {
-        return dispatchPredicate;
-    }
-
-    /**
      * @return a map of data loaders to specific dispatch predicates
      */
     public Map<DataLoader<?, ?>, DispatchPredicate> getDataLoaderPredicates() {
         return new LinkedHashMap<>(dataLoaderPredicates);
+    }
+
+    /**
+     * There is a default predicate that applies to the whole {@link ScheduledDataLoaderRegistry}
+     *
+     * @return the default dispatch predicate
+     */
+    public DispatchPredicate getDispatchPredicate() {
+        return dispatchPredicate;
     }
 
     /**
@@ -281,7 +286,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         }
 
         /**
-         * This sets a predicate on the {@link DataLoaderRegistry} that will control
+         * This sets a default predicate on the {@link DataLoaderRegistry} that will control
          * whether all {@link DataLoader}s in the {@link DataLoaderRegistry }should be dispatched.
          *
          * @param dispatchPredicate the predicate

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -68,7 +68,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      *
      * @return a new combined registry
      */
-    public DataLoaderRegistry combine(DataLoaderRegistry registry) {
+    public ScheduledDataLoaderRegistry combine(DataLoaderRegistry registry) {
         Builder combinedBuilder = ScheduledDataLoaderRegistry.newScheduledRegistry()
                 .dispatchPredicate(this.dispatchPredicate);
         combinedBuilder.registerAll(this);
@@ -115,7 +115,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      *
      * @return this registry
      */
-    public DataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
+    public ScheduledDataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
         dataLoaders.put(key, dataLoader);
         dataLoaderPredicates.put(dataLoader, dispatchPredicate);
         return this;
@@ -206,8 +206,8 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     }
 
     /**
-     * By default this will create use a {@link Executors#newSingleThreadScheduledExecutor()}
-     * and a schedule duration of 10 milli seconds.
+     * By default, this will create use a {@link Executors#newSingleThreadScheduledExecutor()}
+     * and a schedule duration of 10 milliseconds.
      *
      * @return A builder of {@link ScheduledDataLoaderRegistry}s
      */

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -5,7 +5,9 @@ import org.dataloader.DataLoaderRegistry;
 import org.dataloader.annotations.ExperimentalApi;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +30,8 @@ import static org.dataloader.impl.Assertions.nonNull;
 @ExperimentalApi
 public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements AutoCloseable {
 
+    private final Map<DataLoader<?, ?>, DispatchPredicate> dataLoaderPredicates = new ConcurrentHashMap<>();
+    private final DispatchPredicate dispatchPredicate;
     private final ScheduledExecutorService scheduledExecutorService;
     private final Duration schedule;
     private volatile boolean closed;
@@ -37,6 +41,8 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         this.scheduledExecutorService = builder.scheduledExecutorService;
         this.schedule = builder.schedule;
         this.closed = false;
+        this.dispatchPredicate = builder.dispatchPredicate;
+        this.dataLoaderPredicates.putAll(builder.dataLoaderPredicates);
     }
 
     /**
@@ -54,6 +60,86 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         return schedule;
     }
 
+    /**
+     * This will combine all the current data loaders in this registry and all the data loaders from the specified registry
+     * and return a new combined registry
+     *
+     * @param registry the registry to combine into this registry
+     *
+     * @return a new combined registry
+     */
+    public DataLoaderRegistry combine(DataLoaderRegistry registry) {
+        Builder combinedBuilder = ScheduledDataLoaderRegistry.newScheduledRegistry()
+                .dispatchPredicate(this.dispatchPredicate);
+        combinedBuilder.registerAll(this);
+        combinedBuilder.registerAll(registry);
+        return combinedBuilder.build();
+    }
+
+
+    /**
+     * This will unregister a new dataloader
+     *
+     * @param key the key of the data loader to unregister
+     *
+     * @return this registry
+     */
+    public ScheduledDataLoaderRegistry unregister(String key) {
+        DataLoader<?, ?> dataLoader = dataLoaders.remove(key);
+        if (dataLoader != null) {
+            dataLoaderPredicates.remove(dataLoader);
+        }
+        return this;
+    }
+
+    /**
+     * @return the current dispatch predicate
+     */
+    public DispatchPredicate getDispatchPredicate() {
+        return dispatchPredicate;
+    }
+
+    /**
+     * @return a map of data loaders to specific dispatch predicates
+     */
+    public Map<DataLoader<?, ?>, DispatchPredicate> getDataLoaderPredicates() {
+        return new LinkedHashMap<>(dataLoaderPredicates);
+    }
+
+    /**
+     * This will register a new dataloader and dispatch predicate associated with that data loader
+     *
+     * @param key               the key to put the data loader under
+     * @param dataLoader        the data loader to register
+     * @param dispatchPredicate the dispatch predicate to associate with this data loader
+     *
+     * @return this registry
+     */
+    public DataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
+        dataLoaders.put(key, dataLoader);
+        dataLoaderPredicates.put(dataLoader, dispatchPredicate);
+        return this;
+    }
+
+    /**
+     * Returns true if the dataloader has a predicate which returned true, OR the overall
+     * registry predicate returned true.
+     *
+     * @param dataLoaderKey the key in the dataloader map
+     * @param dataLoader    the dataloader
+     *
+     * @return true if it should dispatch
+     */
+    private boolean shouldDispatch(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
+        DispatchPredicate dispatchPredicate = dataLoaderPredicates.get(dataLoader);
+        if (dispatchPredicate != null) {
+            if (dispatchPredicate.test(dataLoaderKey, dataLoader)) {
+                return true;
+            }
+        }
+        return this.dispatchPredicate.test(dataLoaderKey, dataLoader);
+    }
+
     @Override
     public void dispatchAll() {
         dispatchAllWithCount();
@@ -65,7 +151,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         for (Map.Entry<String, DataLoader<?, ?>> entry : dataLoaders.entrySet()) {
             DataLoader<?, ?> dataLoader = entry.getValue();
             String key = entry.getKey();
-            if (dispatchPredicate.test(key, dataLoader)) {
+            if (shouldDispatch(key, dataLoader)) {
                 sum += dataLoader.dispatchWithCounts().getKeysCount();
             } else {
                 reschedule(key, dataLoader);
@@ -73,6 +159,28 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         }
         return sum;
     }
+
+
+    /**
+     * This will immediately dispatch the {@link DataLoader}s in the registry
+     * without testing the predicates
+     */
+    public void dispatchAllImmediately() {
+        dispatchAllWithCountImmediately();
+    }
+
+    /**
+     * This will immediately dispatch the {@link DataLoader}s in the registry
+     * without testing the predicates
+     *
+     * @return total number of entries that were dispatched from registered {@link org.dataloader.DataLoader}s.
+     */
+    public int dispatchAllWithCountImmediately() {
+        return dataLoaders.values().stream()
+                .mapToInt(dataLoader -> dataLoader.dispatchWithCounts().getKeysCount())
+                .sum();
+    }
+
 
     /**
      * This will schedule a task to check the predicate and dispatch if true right now.  It will not do
@@ -112,14 +220,64 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
         private Duration schedule = Duration.ofMillis(10);
 
+        private final Map<DataLoader<?, ?>, DispatchPredicate> dataLoaderPredicates = new ConcurrentHashMap<>();
+
+        private DispatchPredicate dispatchPredicate = DispatchPredicate.DISPATCH_ALWAYS;
+
         public Builder scheduledExecutorService(ScheduledExecutorService executorService) {
             this.scheduledExecutorService = nonNull(executorService);
-            return this;
+            return self();
         }
 
         public Builder schedule(Duration schedule) {
             this.schedule = schedule;
-            return this;
+            return self();
+        }
+
+
+        /**
+         * This will register a new dataloader with a specific {@link DispatchPredicate}
+         *
+         * @param key               the key to put the data loader under
+         * @param dataLoader        the data loader to register
+         * @param dispatchPredicate the dispatch predicate
+         *
+         * @return this builder for a fluent pattern
+         */
+        public Builder register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
+            register(key, dataLoader);
+            dataLoaderPredicates.put(dataLoader, dispatchPredicate);
+            return self();
+        }
+
+        /**
+         * This will combine the data loaders in this builder with the ones
+         * from a previous {@link DataLoaderRegistry}
+         *
+         * @param otherRegistry the previous {@link DataLoaderRegistry}
+         *
+         * @return this builder for a fluent pattern
+         */
+        public Builder registerAll(DataLoaderRegistry otherRegistry) {
+            super.registerAll(otherRegistry);
+            if (otherRegistry instanceof ScheduledDataLoaderRegistry) {
+                ScheduledDataLoaderRegistry other = (ScheduledDataLoaderRegistry) otherRegistry;
+                dataLoaderPredicates.putAll(other.dataLoaderPredicates);
+            }
+            return self();
+        }
+
+        /**
+         * This sets a predicate on the {@link DataLoaderRegistry} that will control
+         * whether all {@link DataLoader}s in the {@link DataLoaderRegistry }should be dispatched.
+         *
+         * @param dispatchPredicate the predicate
+         *
+         * @return this builder for a fluent pattern
+         */
+        public Builder dispatchPredicate(DispatchPredicate dispatchPredicate) {
+            this.dispatchPredicate = dispatchPredicate;
+            return self();
         }
 
         /**

--- a/src/test/java/org/dataloader/DataLoaderRegistryPredicateTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryPredicateTest.java
@@ -133,13 +133,13 @@ public class DataLoaderRegistryPredicateTest {
         DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
         DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
 
-        DispatchPredicate predicateOverAllOnThree = new CountingDispatchPredicate(3);
+        DispatchPredicate predicateOnSix = new CountingDispatchPredicate(6);
 
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
                 .register("a", dlA, DISPATCH_NEVER)
                 .register("b", dlB, DISPATCH_NEVER)
                 .register("c", dlC, DISPATCH_NEVER)
-                .dispatchPredicate(predicateOverAllOnThree)
+                .dispatchPredicate(predicateOnSix)
                 .build();
 
 
@@ -148,13 +148,18 @@ public class DataLoaderRegistryPredicateTest {
         CompletableFuture<Object> cfC = dlC.load("C");
 
         int count = registry.dispatchAllWithCount(); // first firing
-        // none should fire
         assertThat(count, equalTo(0));
         assertThat(cfA.isDone(), equalTo(false));
         assertThat(cfB.isDone(), equalTo(false));
         assertThat(cfC.isDone(), equalTo(false));
 
-        count = registry.dispatchAllWithCount(); // second firing but the overall been asked 3 times already
+        count = registry.dispatchAllWithCount(); // second firing but the overall been asked 6 times already
+        assertThat(count, equalTo(0));
+        assertThat(cfA.isDone(), equalTo(false));
+        assertThat(cfB.isDone(), equalTo(false));
+        assertThat(cfC.isDone(), equalTo(false));
+
+        count = registry.dispatchAllWithCount(); // third firing but the overall been asked 9 times already
         assertThat(count, equalTo(3));
         assertThat(cfA.isDone(), equalTo(true));
         assertThat(cfB.isDone(), equalTo(true));

--- a/src/test/java/org/dataloader/DataLoaderRegistryPredicateTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryPredicateTest.java
@@ -1,0 +1,198 @@
+package org.dataloader;
+
+import org.dataloader.registries.DispatchPredicate;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Arrays.asList;
+import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.dataloader.fixtures.TestKit.asSet;
+import static org.dataloader.registries.DispatchPredicate.DISPATCH_NEVER;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class DataLoaderRegistryPredicateTest {
+    final BatchLoader<Object, Object> identityBatchLoader = CompletableFuture::completedFuture;
+
+    static class CountingDispatchPredicate implements DispatchPredicate {
+        int count = 0;
+        int max = 0;
+
+        public CountingDispatchPredicate(int max) {
+            this.max = max;
+        }
+
+        @Override
+        public boolean test(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
+            boolean shouldFire = count >= max;
+            count++;
+            return shouldFire;
+        }
+    }
+
+    @Test
+    public void predicate_registration_works() {
+        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+
+        DispatchPredicate predicateA = new CountingDispatchPredicate(1);
+        DispatchPredicate predicateB = new CountingDispatchPredicate(2);
+        DispatchPredicate predicateC = new CountingDispatchPredicate(3);
+
+        DispatchPredicate predicateOverAll = new CountingDispatchPredicate(10);
+
+        DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
+                .register("a", dlA, predicateA)
+                .register("b", dlB, predicateB)
+                .register("c", dlC, predicateC)
+                .dispatchPredicate(predicateOverAll)
+                .build();
+
+        assertThat(registry.getDataLoaders(), equalTo(asList(dlA, dlB, dlC)));
+        assertThat(registry.getDataLoadersMap().keySet(), equalTo(asSet("a", "b", "c")));
+        assertThat(asSet(registry.getDataLoadersMap().values()), equalTo(asSet(dlA, dlB, dlC)));
+        assertThat(registry.getDispatchPredicate(), equalTo(predicateOverAll));
+        assertThat(asSet(registry.getDataLoaderPredicates().values()), equalTo(asSet(predicateA, predicateB, predicateC)));
+
+        // and unregister (fluently)
+        DataLoaderRegistry dlR = registry.unregister("c");
+        assertThat(dlR, equalTo(registry));
+
+        assertThat(registry.getDataLoaders(), equalTo(asList(dlA, dlB)));
+        assertThat(registry.getDispatchPredicate(), equalTo(predicateOverAll));
+        assertThat(asSet(registry.getDataLoaderPredicates().values()), equalTo(asSet(predicateA, predicateB)));
+
+        // direct on the registry works
+        registry.register("c", dlC, predicateC);
+        assertThat(registry.getDataLoaders(), equalTo(asList(dlA, dlB, dlC)));
+        assertThat(registry.getDispatchPredicate(), equalTo(predicateOverAll));
+        assertThat(asSet(registry.getDataLoaderPredicates().values()), equalTo(asSet(predicateA, predicateB, predicateC)));
+
+    }
+
+    @Test
+    public void predicate_firing_works() {
+        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+
+        DispatchPredicate predicateA = new CountingDispatchPredicate(1);
+        DispatchPredicate predicateB = new CountingDispatchPredicate(2);
+        DispatchPredicate predicateC = new CountingDispatchPredicate(3);
+
+        DispatchPredicate predicateOverAll = new CountingDispatchPredicate(10);
+
+        DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
+                .register("a", dlA, predicateA)
+                .register("b", dlB, predicateB)
+                .register("c", dlC, predicateC)
+                .dispatchPredicate(predicateOverAll)
+                .build();
+
+
+        CompletableFuture<Object> cfA = dlA.load("A");
+        CompletableFuture<Object> cfB = dlB.load("B");
+        CompletableFuture<Object> cfC = dlC.load("C");
+
+        int count = registry.dispatchAllWithCount(); // first firing
+        // none should fire
+        assertThat(count, equalTo(0));
+        assertThat(cfA.isDone(), equalTo(false));
+        assertThat(cfB.isDone(), equalTo(false));
+        assertThat(cfC.isDone(), equalTo(false));
+
+        count = registry.dispatchAllWithCount(); // second firing
+        // one should fire
+        assertThat(count, equalTo(1));
+        assertThat(cfA.isDone(), equalTo(true));
+        assertThat(cfA.join(), equalTo("A"));
+
+        assertThat(cfB.isDone(), equalTo(false));
+        assertThat(cfC.isDone(), equalTo(false));
+
+        count = registry.dispatchAllWithCount(); // third firing
+        assertThat(count, equalTo(1));
+        assertThat(cfA.isDone(), equalTo(true));
+        assertThat(cfB.isDone(), equalTo(true));
+        assertThat(cfB.join(), equalTo("B"));
+        assertThat(cfC.isDone(), equalTo(false));
+
+        count = registry.dispatchAllWithCount(); // fourth firing
+        assertThat(count, equalTo(1));
+        assertThat(cfA.isDone(), equalTo(true));
+        assertThat(cfB.isDone(), equalTo(true));
+        assertThat(cfC.isDone(), equalTo(true));
+        assertThat(cfC.join(), equalTo("C"));
+    }
+
+    @Test
+    public void test_the_registry_overall_predicate_firing_works() {
+        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+
+        DispatchPredicate predicateOverAllOnThree = new CountingDispatchPredicate(3);
+
+        DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
+                .register("a", dlA, DISPATCH_NEVER)
+                .register("b", dlB, DISPATCH_NEVER)
+                .register("c", dlC, DISPATCH_NEVER)
+                .dispatchPredicate(predicateOverAllOnThree)
+                .build();
+
+
+        CompletableFuture<Object> cfA = dlA.load("A");
+        CompletableFuture<Object> cfB = dlB.load("B");
+        CompletableFuture<Object> cfC = dlC.load("C");
+
+        int count = registry.dispatchAllWithCount(); // first firing
+        // none should fire
+        assertThat(count, equalTo(0));
+        assertThat(cfA.isDone(), equalTo(false));
+        assertThat(cfB.isDone(), equalTo(false));
+        assertThat(cfC.isDone(), equalTo(false));
+
+        count = registry.dispatchAllWithCount(); // second firing but the overall been asked 3 times already
+        assertThat(count, equalTo(3));
+        assertThat(cfA.isDone(), equalTo(true));
+        assertThat(cfB.isDone(), equalTo(true));
+        assertThat(cfC.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void dispatch_immediate_firing_works() {
+        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+
+        DispatchPredicate predicateA = new CountingDispatchPredicate(1);
+        DispatchPredicate predicateB = new CountingDispatchPredicate(2);
+        DispatchPredicate predicateC = new CountingDispatchPredicate(3);
+
+        DispatchPredicate predicateOverAll = new CountingDispatchPredicate(10);
+
+        DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
+                .register("a", dlA, predicateA)
+                .register("b", dlB, predicateB)
+                .register("c", dlC, predicateC)
+                .dispatchPredicate(predicateOverAll)
+                .build();
+
+
+        CompletableFuture<Object> cfA = dlA.load("A");
+        CompletableFuture<Object> cfB = dlB.load("B");
+        CompletableFuture<Object> cfC = dlC.load("C");
+
+        int count = registry.dispatchAllWithCountImmediately(); // all should fire
+        assertThat(count, equalTo(3));
+        assertThat(cfA.isDone(), equalTo(true));
+        assertThat(cfA.join(), equalTo("A"));
+        assertThat(cfB.isDone(), equalTo(true));
+        assertThat(cfB.join(), equalTo("B"));
+        assertThat(cfC.isDone(), equalTo(true));
+        assertThat(cfC.join(), equalTo("C"));
+    }
+
+}

--- a/src/test/java/org/dataloader/fixtures/TestKit.java
+++ b/src/test/java/org/dataloader/fixtures/TestKit.java
@@ -6,8 +6,11 @@ import org.dataloader.DataLoaderFactory;
 import org.dataloader.DataLoaderOptions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.stream.Collectors.toList;
@@ -66,5 +69,13 @@ public class TestKit {
 
     public static <T> List<T> sort(Collection<? extends T> collection) {
         return collection.stream().sorted().collect(toList());
+    }
+
+    public static <T> Set<T> asSet(T... elements) {
+        return new LinkedHashSet<>(Arrays.asList(elements));
+    }
+
+    public static <T> Set<T> asSet(Collection<T> elements) {
+        return new LinkedHashSet<>(elements);
     }
 }


### PR DESCRIPTION
This adds a map of per dataloader predicates to ScheduledDataLoaderRegistry so people can have more fine grain control on when a dataloader is dispatched.

if its not used then it goes back to the default behavior of one predicate for the ScheduledDataLoaderRegistry