### PR TITLE
If there is a specific predicate for a dataloader - its is the final say on whether to dispatch

### DIFF
--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -217,8 +217,8 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     }
 
     /**
-     * Returns true if the dataloader has a predicate which returned true, OR the overall
-     * registry predicate returned true.
+     * If a specific {@link DispatchPredicate} is registered for this dataloader then it uses it values
+     * otherwise the overall registry predicate is used.
      *
      * @param dataLoaderKey the key in the dataloader map
      * @param dataLoader    the dataloader
@@ -228,9 +228,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
     private boolean shouldDispatch(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
         DispatchPredicate dispatchPredicate = dataLoaderPredicates.get(dataLoader);
         if (dispatchPredicate != null) {
-            if (dispatchPredicate.test(dataLoaderKey, dataLoader)) {
-                return true;
-            }
+            return dispatchPredicate.test(dataLoaderKey, dataLoader);
         }
         return this.dispatchPredicate.test(dataLoaderKey, dataLoader);
     }


### PR DESCRIPTION
See https://github.com/graphql-java/java-dataloader/issues/138

This changes the dispatcing predicate so that IF a specific predicate is regisestered against a data loader - its answer is final.

The old code defaulted and on reflection thats just janky defaulting