### PR TITLE
Remove CacheMap#containsKey before #get

### DIFF
--- a/src/main/java/org/dataloader/CacheMap.java
+++ b/src/main/java/org/dataloader/CacheMap.java
@@ -65,8 +65,7 @@ public interface CacheMap<K, V> {
     /**
      * Gets the specified key from the cache map.
      * <p>
-     * May throw an exception if the key does not exist, depending on the cache map implementation that is used,
-     * so be sure to check {@link CacheMap#containsKey(Object)} first.
+     * May throw an exception if the key does not exist, depending on the cache map implementation that is used.
      *
      * @param key the key to retrieve
      *


### PR DESCRIPTION
Currently, when accessing values from the `DataLoader`'s `CacheMap`, we first check `#containsKey` before invoking `#get`. This is problematic for two reasons:

 - the underlying cache's metrics are skewed (it will have a 100% hit rate).
 - if the cache has an automatic expiration policy, it is possible a value will expire between the `containsKey` and `get` invocations leading to an incorrect result.

To ameliorate this, we always invoke `#get` and check if it is `null` to deterine whether the key is present. We wrap the invocation in a `try`/`catch` as the `#get` method is allowed to through per its documentation.