### PR TITLE
Bump JUnit 4.x to JUnit Jupiter 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,11 @@ dependencies {
     api 'org.slf4j:slf4j-api:' + slf4jVersion
     testImplementation 'org.slf4j:slf4j-simple:' + slf4jVersion
     testImplementation 'org.awaitility:awaitility:2.0.0'
+    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation 'com.github.ben-manes.caffeine:caffeine:2.9.0'
-
     testImplementation platform('org.junit:junit-bom:5.10.2')
-    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 task sourcesJar(type: Jar) {
@@ -98,6 +99,7 @@ test {
     testLogging {
         exceptionFormat = 'full'
     }
+    useJUnitPlatform()
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,11 @@ jar {
 dependencies {
     api 'org.slf4j:slf4j-api:' + slf4jVersion
     testImplementation 'org.slf4j:slf4j-simple:' + slf4jVersion
-    testImplementation 'junit:junit:4.12'
     testImplementation 'org.awaitility:awaitility:2.0.0'
     testImplementation 'com.github.ben-manes.caffeine:caffeine:2.9.0'
+
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.vintage:junit-vintage-engine'
 }
 
 task sourcesJar(type: Jar) {

--- a/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
@@ -1,6 +1,6 @@
 package org.dataloader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,8 +14,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.DataLoaderFactory.newMappedDataLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests related to context.  DataLoaderTest is getting to big and needs refactoring

--- a/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
+++ b/src/test/java/org/dataloader/DataLoaderCacheMapTest.java
@@ -1,6 +1,6 @@
 package org.dataloader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for cacheMap functionality..

--- a/src/test/java/org/dataloader/DataLoaderIfPresentTest.java
+++ b/src/test/java/org/dataloader/DataLoaderIfPresentTest.java
@@ -1,15 +1,15 @@
 package org.dataloader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for IfPresent and IfCompleted functionality.

--- a/src/test/java/org/dataloader/DataLoaderMapBatchLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderMapBatchLoaderTest.java
@@ -1,6 +1,6 @@
 package org.dataloader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -19,10 +19,10 @@ import static org.dataloader.DataLoaderOptions.newOptions;
 import static org.dataloader.fixtures.TestKit.futureError;
 import static org.dataloader.fixtures.TestKit.listFrom;
 import static org.dataloader.impl.CompletableFutureKit.cause;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Much of the tests that related to {@link MappedBatchLoader} also related to

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -2,16 +2,16 @@ package org.dataloader;
 
 import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.Statistics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Arrays.asList;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 public class DataLoaderRegistryTest {
     final BatchLoader<Object, Object> identityBatchLoader = CompletableFuture::completedFuture;

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -9,7 +9,7 @@ import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsCo
 import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
 import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
 import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,9 +19,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests related to stats.  DataLoaderTest is getting to big and needs refactoring

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -22,7 +22,7 @@ import org.dataloader.fixtures.TestKit;
 import org.dataloader.fixtures.User;
 import org.dataloader.fixtures.UserManager;
 import org.dataloader.impl.CompletableFutureKit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,12 +43,12 @@ import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.DataLoaderOptions.newOptions;
 import static org.dataloader.fixtures.TestKit.listFrom;
 import static org.dataloader.impl.CompletableFutureKit.cause;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Tests for {@link DataLoader}.

--- a/src/test/java/org/dataloader/DataLoaderTimeTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTimeTest.java
@@ -1,13 +1,13 @@
 package org.dataloader;
 
 import org.dataloader.fixtures.TestingClock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
 import static org.dataloader.fixtures.TestKit.keysAsValues;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 @SuppressWarnings("UnusedReturnValue")
 public class DataLoaderTimeTest {

--- a/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
+++ b/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
@@ -5,7 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.dataloader.fixtures.CaffeineValueCache;
 import org.dataloader.fixtures.CustomValueCache;
 import org.dataloader.impl.DataLoaderAssertionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,11 +22,11 @@ import static org.dataloader.fixtures.TestKit.idLoader;
 import static org.dataloader.fixtures.TestKit.snooze;
 import static org.dataloader.fixtures.TestKit.sort;
 import static org.dataloader.impl.CompletableFutureKit.failedFuture;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DataLoaderValueCacheTest {
 

--- a/src/test/java/org/dataloader/DataLoaderWithTryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderWithTryTest.java
@@ -1,7 +1,7 @@
 package org.dataloader;
 
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,9 +12,9 @@ import java.util.concurrent.CompletableFuture;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.dataloader.DataLoaderFactory.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 public class DataLoaderWithTryTest {
 

--- a/src/test/java/org/dataloader/TryTest.java
+++ b/src/test/java/org/dataloader/TryTest.java
@@ -1,7 +1,7 @@
 package org.dataloader;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -9,11 +9,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TryTest {
 
@@ -29,7 +29,7 @@ public class TryTest {
                 return;
             }
         }
-        Assert.fail("Expected throwable :  " + throwableClass.getName());
+        Assertions.fail("Expected throwable :  " + throwableClass.getName());
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/org/dataloader/impl/PromisedValuesImplTest.java
+++ b/src/test/java/org/dataloader/impl/PromisedValuesImplTest.java
@@ -1,6 +1,6 @@
 package org.dataloader.impl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,12 +12,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 public class PromisedValuesImplTest {
 

--- a/src/test/java/org/dataloader/registries/DispatchPredicateTest.java
+++ b/src/test/java/org/dataloader/registries/DispatchPredicateTest.java
@@ -4,12 +4,12 @@ import org.dataloader.ClockDataLoader;
 import org.dataloader.DataLoader;
 import org.dataloader.fixtures.TestKit;
 import org.dataloader.fixtures.TestingClock;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DispatchPredicateTest {
 

--- a/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryPredicateTest.java
+++ b/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryPredicateTest.java
@@ -3,7 +3,7 @@ package org.dataloader.registries;
 import org.dataloader.BatchLoader;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -12,10 +12,9 @@ import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.fixtures.TestKit.asSet;
-import static org.dataloader.registries.DispatchPredicate.DISPATCH_NEVER;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class ScheduledDataLoaderRegistryPredicateTest {
     final BatchLoader<Object, Object> identityBatchLoader = CompletableFuture::completedFuture;

--- a/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/registries/ScheduledDataLoaderRegistryTest.java
@@ -1,11 +1,11 @@
 package org.dataloader.registries;
 
-import junit.framework.TestCase;
 import org.awaitility.core.ConditionTimeoutException;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderFactory;
 import org.dataloader.DataLoaderRegistry;
 import org.dataloader.fixtures.TestKit;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -22,17 +22,22 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Duration.TWO_SECONDS;
 import static org.dataloader.fixtures.TestKit.keysAsValues;
 import static org.dataloader.fixtures.TestKit.snooze;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class ScheduledDataLoaderRegistryTest extends TestCase {
+public class ScheduledDataLoaderRegistryTest {
 
     DispatchPredicate alwaysDispatch = (key, dl) -> true;
     DispatchPredicate neverDispatch = (key, dl) -> false;
 
 
-    public void test_basic_setup_works_like_a_normal_dlr() {
+    @Test
+    public void basic_setup_works_like_a_normal_dlr() {
 
         List<List<String>> aCalls = new ArrayList<>();
         List<List<String>> bCalls = new ArrayList<>();
@@ -63,7 +68,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(bCalls, equalTo(singletonList(asList("BK1", "BK2"))));
     }
 
-    public void test_predicate_always_false() {
+    @Test
+    public void predicate_always_false() {
 
         List<List<String>> calls = new ArrayList<>();
         DataLoader<String, String> dlA = DataLoaderFactory.newDataLoader(keysAsValues(calls));
@@ -92,7 +98,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(calls.size(), equalTo(0));
     }
 
-    public void test_predicate_that_eventually_returns_true() {
+    @Test
+    public void predicate_that_eventually_returns_true() {
 
 
         AtomicInteger counter = new AtomicInteger();
@@ -123,7 +130,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertTrue(p2.isDone());
     }
 
-    public void test_dispatchAllWithCountImmediately() {
+    @Test
+    public void dispatchAllWithCountImmediately() {
         List<List<String>> calls = new ArrayList<>();
         DataLoader<String, String> dlA = DataLoaderFactory.newDataLoader(keysAsValues(calls));
         dlA.load("K1");
@@ -140,7 +148,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(calls, equalTo(singletonList(asList("K1", "K2"))));
     }
 
-    public void test_dispatchAllImmediately() {
+    @Test
+    public void dispatchAllImmediately() {
         List<List<String>> calls = new ArrayList<>();
         DataLoader<String, String> dlA = DataLoaderFactory.newDataLoader(keysAsValues(calls));
         dlA.load("K1");
@@ -156,7 +165,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(calls, equalTo(singletonList(asList("K1", "K2"))));
     }
 
-    public void test_rescheduleNow() {
+    @Test
+    public void rescheduleNow() {
         AtomicInteger i = new AtomicInteger();
         DispatchPredicate countingPredicate = (dataLoaderKey, dataLoader) -> i.incrementAndGet() > 5;
 
@@ -179,7 +189,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(calls, equalTo(singletonList(asList("K1", "K2"))));
     }
 
-    public void test_it_will_take_out_the_schedule_once_it_dispatches() {
+    @Test
+    public void it_will_take_out_the_schedule_once_it_dispatches() {
         AtomicInteger counter = new AtomicInteger();
         DispatchPredicate countingPredicate = (dataLoaderKey, dataLoader) -> counter.incrementAndGet() > 5;
 
@@ -220,7 +231,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertThat(calls, equalTo(asList(asList("K1", "K2"), asList("K3", "K4"))));
     }
 
-    public void test_close_is_a_one_way_door() {
+    @Test
+    public void close_is_a_one_way_door() {
         AtomicInteger counter = new AtomicInteger();
         DispatchPredicate countingPredicate = (dataLoaderKey, dataLoader) -> {
             counter.incrementAndGet();
@@ -264,7 +276,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         assertEquals(counter.get(), countThen + 1);
     }
 
-    public void test_can_tick_after_first_dispatch_for_chain_data_loaders() {
+    @Test
+    public void can_tick_after_first_dispatch_for_chain_data_loaders() {
 
         // delays much bigger than the tick rate will mean multiple calls to dispatch
         DataLoader<String, String> dlA = TestKit.idLoaderAsync(Duration.ofMillis(100));
@@ -293,7 +306,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         registry.close();
     }
 
-    public void test_chain_data_loaders_will_hang_if_not_in_ticker_mode() {
+    @Test
+    public void chain_data_loaders_will_hang_if_not_in_ticker_mode() {
 
         // delays much bigger than the tick rate will mean multiple calls to dispatch
         DataLoader<String, String> dlA = TestKit.idLoaderAsync(Duration.ofMillis(100));
@@ -325,7 +339,8 @@ public class ScheduledDataLoaderRegistryTest extends TestCase {
         registry.close();
     }
 
-    public void test_executors_are_shutdown() {
+    @Test
+    public void executors_are_shutdown() {
         ScheduledDataLoaderRegistry registry = ScheduledDataLoaderRegistry.newScheduledRegistry().build();
 
         ScheduledExecutorService executorService = registry.getScheduledExecutorService();

--- a/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
+++ b/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
@@ -3,7 +3,7 @@ package org.dataloader.scheduler;
 import org.dataloader.BatchLoaderEnvironment;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -20,8 +20,8 @@ import static org.dataloader.fixtures.TestKit.keysAsMapOfValuesWithContext;
 import static org.dataloader.fixtures.TestKit.keysAsValues;
 import static org.dataloader.fixtures.TestKit.keysAsValuesWithContext;
 import static org.dataloader.fixtures.TestKit.snooze;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class BatchLoaderSchedulerTest {
 

--- a/src/test/java/org/dataloader/stats/StatisticsCollectorTest.java
+++ b/src/test/java/org/dataloader/stats/StatisticsCollectorTest.java
@@ -5,13 +5,13 @@ import org.dataloader.stats.context.IncrementBatchLoadExceptionCountStatisticsCo
 import org.dataloader.stats.context.IncrementCacheHitCountStatisticsContext;
 import org.dataloader.stats.context.IncrementLoadCountStatisticsContext;
 import org.dataloader.stats.context.IncrementLoadErrorCountStatisticsContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class StatisticsCollectorTest {
 

--- a/src/test/java/org/dataloader/stats/StatisticsTest.java
+++ b/src/test/java/org/dataloader/stats/StatisticsTest.java
@@ -1,11 +1,11 @@
 package org.dataloader.stats;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class StatisticsTest {
 


### PR DESCRIPTION
This change is being made to facilitate parameterised tests which should greatly aid in adding coverage for https://github.com/graphql-java/java-dataloader/pull/148.

This was largely powered by the [OpenRewrite recipe](https://docs.openrewrite.org/recipes/java/testing/junit5/junit4to5migration) for JUnit 4.x to Jupiter migration, with a few extra tweaks:

 - imports optimised to be single-class (i.e. no `import foo.*;`).
 - removed `test_` prefix from legacy JUnit 3 methods.

Notably, this pulls in `org.hamcrest` for `MatcherAssert.assertThat`, which is recommended by both the recipe (which handled this migration) and IntelliJ.