### PR TITLE
Removing unused slf4j references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ jar {
 }
 
 dependencies {
-    api "org.slf4j:slf4j-api:$slf4j_version"
     api "org.reactivestreams:reactive-streams:$reactive_streams_version"
 }
 
@@ -99,7 +98,6 @@ testing {
                 implementation 'org.junit.jupiter:junit-jupiter-api'
                 implementation 'org.junit.jupiter:junit-jupiter-params'
                 implementation 'org.junit.jupiter:junit-jupiter-engine'
-                implementation "org.slf4j:slf4j-simple:$slf4j_version"
                 implementation "org.awaitility:awaitility:$awaitility_version"
                 implementation "org.hamcrest:hamcrest:$hamcrest_version"
                 implementation "io.projectreactor:reactor-core:$reactor_core_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ projectDescription = Port of Facebook Dataloader for Java
 # Dependency versions.
 junit_version=5.11.3
 hamcrest_version=2.2
-slf4j_version=1.7.30
 awaitility_version=2.0.0
 reactor_core_version=3.6.6
 caffeine_version=3.1.8


### PR DESCRIPTION
A while back we removed SLF4J from GraphQL Java. https://github.com/graphql-java/graphql-java/pull/3403/files Apart from the difficult PII/UGC problems, it was also causing unusual version clashes for users.

I spotted we still had SLF4J mentioned in this repo, but we don't seem to use it at all. Let's remove it to keep the set of dependencies to a minimum