### PR TITLE
Allow ValueCache to work with Publisher DataLoader

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -390,6 +390,9 @@ class DataLoaderHelper<K, V> {
                         missedKeyIndexes.add(i);
                         missedKeys.add(keys.get(i));
                         missedKeyContexts.add(keyContexts.get(i));
+                        missedQueuedFutures.add(queuedFutures.get(i));
+                    } else {
+                        queuedFutures.get(i).complete(cacheGet.get());
                     }
                 }
             }

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -29,10 +29,8 @@ import org.dataloader.fixtures.parameterized.TestDataLoaderFactory;
 import org.dataloader.fixtures.parameterized.TestReactiveDataLoaderFactory;
 import org.dataloader.impl.CompletableFutureKit;
 import org.dataloader.impl.DataLoaderAssertionException;
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.*;
@@ -41,21 +39,14 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
 import static java.util.concurrent.CompletableFuture.*;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
-import static org.dataloader.DataLoaderFactory.newMappedDataLoader;
-import static org.dataloader.DataLoaderFactory.newMappedPublisherDataLoader;
-import static org.dataloader.DataLoaderFactory.newMappedPublisherDataLoaderWithTry;
-import static org.dataloader.DataLoaderFactory.newPublisherDataLoader;
-import static org.dataloader.DataLoaderFactory.newPublisherDataLoaderWithTry;
 import static org.dataloader.DataLoaderOptions.newOptions;
 import static org.dataloader.fixtures.TestKit.areAllDone;
 import static org.dataloader.fixtures.TestKit.listFrom;
@@ -63,7 +54,6 @@ import static org.dataloader.impl.CompletableFutureKit.cause;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for {@link DataLoader}.
@@ -125,7 +115,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Support_loading_multiple_keys_in_one_call_via_list(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -141,7 +131,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Support_loading_multiple_keys_in_one_call_via_map(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -161,7 +151,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Resolve_to_empty_list_when_no_keys_supplied(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -176,7 +166,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Resolve_to_empty_map_when_no_keys_supplied(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -191,7 +181,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Return_zero_entries_dispatched_when_no_keys_supplied_via_list(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -206,7 +196,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Return_zero_entries_dispatched_when_no_keys_supplied_via_map(TestDataLoaderFactory factory) {
         AtomicBoolean success = new AtomicBoolean();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), new ArrayList<>());
@@ -221,7 +211,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Batch_multiple_requests(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -237,7 +227,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Return_number_of_batched_entries(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -252,7 +242,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Coalesce_identical_requests(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -269,7 +259,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Cache_repeated_requests(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -305,7 +295,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Not_redispatch_previous_load(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -323,7 +313,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Cache_on_redispatch(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -348,7 +338,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_single_value_in_loader(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -377,7 +367,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_all_values_in_loader(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -405,7 +395,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_priming_the_cache(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -424,7 +414,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Not_prime_keys_that_already_exist(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -453,7 +443,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_to_forcefully_prime_the_cache(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -482,7 +472,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_priming_the_cache_with_a_future(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -501,7 +491,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_not_Cache_failed_fetches_on_complete_failure(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> errorLoader = factory.idLoaderBlowsUps(new DataLoaderOptions(), loadCalls);
@@ -523,7 +513,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Resolve_to_error_to_indicate_failure(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Object> evenLoader = factory.idLoaderOddEvenExceptions(new DataLoaderOptions(), loadCalls);
@@ -546,7 +536,7 @@ public class DataLoaderTest {
     // Accept any kind of key.
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Represent_failures_and_successes_simultaneously(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         AtomicBoolean success = new AtomicBoolean();
         List<Collection<Integer>> loadCalls = new ArrayList<>();
@@ -573,7 +563,7 @@ public class DataLoaderTest {
     // Accepts options
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Cache_failed_fetches(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Object> errorLoader = factory.idLoaderAllExceptions(new DataLoaderOptions(), loadCalls);
@@ -596,7 +586,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_NOT_Cache_failed_fetches_if_told_not_too(TestDataLoaderFactory factory) {
         DataLoaderOptions options = DataLoaderOptions.newOptions().setCachingExceptionsEnabled(false);
         List<Collection<Integer>> loadCalls = new ArrayList<>();
@@ -623,7 +613,7 @@ public class DataLoaderTest {
     // Accepts object key in custom cacheKey function
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Handle_priming_the_cache_with_an_error(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -640,7 +630,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_values_from_cache_after_errors(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> errorLoader = factory.idLoaderBlowsUps(new DataLoaderOptions(), loadCalls);
@@ -676,7 +666,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Propagate_error_to_all_loads(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> errorLoader = factory.idLoaderBlowsUps(new DataLoaderOptions(), loadCalls);
@@ -700,7 +690,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_as_keys(TestDataLoaderFactory factory) {
         List<Collection<Object>> loadCalls = new ArrayList<>();
         DataLoader<Object, Object> identityLoader = factory.idLoader(new DataLoaderOptions(), loadCalls);
@@ -742,7 +732,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Disable_caching(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
@@ -780,7 +770,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_work_with_duplicate_keys_when_caching_disabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
@@ -803,7 +793,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_work_with_duplicate_keys_when_caching_enabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
@@ -824,7 +814,7 @@ public class DataLoaderTest {
     // It is resilient to job queue ordering
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_a_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
@@ -846,7 +836,7 @@ public class DataLoaderTest {
     // Helper methods
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_objects_with_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
@@ -871,7 +861,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_different_order_of_keys(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
@@ -894,7 +884,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_priming_the_cache_with_an_object_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
@@ -916,7 +906,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_a_custom_cache_map_implementation(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         CustomCacheMap customMap = new CustomCacheMap();
         List<Collection<String>> loadCalls = new ArrayList<>();
@@ -968,7 +958,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_degrade_gracefully_if_cache_get_throws(TestDataLoaderFactory factory) {
         CacheMap<String, Object> cache = new ThrowingCacheMap();
         DataLoaderOptions options = newOptions().setCachingEnabled(true).setCacheMap(cache);
@@ -983,7 +973,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_should_dispatch_immediately(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setBatchingEnabled(false);
@@ -1012,7 +1002,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_and_caching_disabled_should_dispatch_immediately_and_forget(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions().setBatchingEnabled(false).setCachingEnabled(false);
@@ -1044,7 +1034,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batches_multiple_requests_with_max_batch_size(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(2), loadCalls);
@@ -1066,7 +1056,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void can_split_max_batch_sizes_correctly(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(5), loadCalls);
@@ -1089,7 +1079,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Batch_loads_occurring_within_futures(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(newOptions(), loadCalls);
@@ -1122,7 +1112,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_blowup_after_N_keys(TestDataLoaderFactory factory) {
         if (!(factory instanceof TestReactiveDataLoaderFactory)) {
             return;
@@ -1148,7 +1138,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void when_values_size_are_less_then_key_size(TestDataLoaderFactory factory) {
         //
         // what happens if we want 4 values but are only given 2 back say
@@ -1183,7 +1173,7 @@ public class DataLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("dataLoaderFactories")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void when_values_size_are_more_then_key_size(TestDataLoaderFactory factory) {
         //
         // what happens if we want 4 values but only given 6 back say
@@ -1306,15 +1296,6 @@ public class DataLoaderTest {
         public CompletableFuture<Object> get(String key) {
             throw new RuntimeException("Cache implementation failed.");
         }
-    }
-
-    private static Stream<Arguments> dataLoaderFactories() {
-        return Stream.of(
-                Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
-                Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory())),
-                Arguments.of(Named.of("Publisher DataLoader", new PublisherDataLoaderFactory())),
-                Arguments.of(Named.of("Mapped Publisher DataLoader", new MappedPublisherDataLoaderFactory()))
-        );
     }
 }
 

--- a/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
+++ b/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DataLoaderValueCacheTest {
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void test_by_default_we_have_no_value_caching(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoaderOptions options = newOptions();
@@ -68,7 +68,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_accept_a_remote_value_store_for_caching(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache();
         List<Collection<String>> loadCalls = new ArrayList<>();
@@ -113,7 +113,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void can_use_caffeine_for_caching(TestDataLoaderFactory factory) {
         //
         // Mostly to prove that some other CACHE library could be used
@@ -154,7 +154,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void will_invoke_loader_if_CACHE_GET_call_throws_exception(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache() {
 
@@ -185,7 +185,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void will_still_work_if_CACHE_SET_call_throws_exception(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache() {
             @Override
@@ -214,7 +214,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void caching_can_take_some_time_complete(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache() {
 
@@ -256,7 +256,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batch_caching_works_as_expected(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache() {
 
@@ -303,7 +303,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void assertions_will_be_thrown_if_the_cache_does_not_follow_contract(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache() {
 
@@ -346,7 +346,7 @@ public class DataLoaderValueCacheTest {
 
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void if_caching_is_off_its_never_hit(TestDataLoaderFactory factory) {
         AtomicInteger getCalls = new AtomicInteger();
         CustomValueCache customValueCache = new CustomValueCache() {
@@ -380,7 +380,7 @@ public class DataLoaderValueCacheTest {
     }
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void if_everything_is_cached_no_batching_happens(TestDataLoaderFactory factory) {
         AtomicInteger getCalls = new AtomicInteger();
         AtomicInteger setCalls = new AtomicInteger();
@@ -423,7 +423,7 @@ public class DataLoaderValueCacheTest {
 
 
     @ParameterizedTest
-    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#getWithoutPublisher")
+    @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void if_batching_is_off_it_still_can_cache(TestDataLoaderFactory factory) {
         AtomicInteger getCalls = new AtomicInteger();
         AtomicInteger setCalls = new AtomicInteger();

--- a/src/test/java/org/dataloader/fixtures/TestKit.java
+++ b/src/test/java/org/dataloader/fixtures/TestKit.java
@@ -8,7 +8,6 @@ import org.dataloader.DataLoaderOptions;
 import org.dataloader.MappedBatchLoader;
 import org.dataloader.MappedBatchLoaderWithContext;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,41 +60,12 @@ public class TestKit {
         };
     }
 
-    public static <K, V> BatchLoader<K, V> keysAsValuesAsync(Duration delay) {
-        return keysAsValuesAsync(new ArrayList<>(), delay);
-    }
-
-    public static <K, V> BatchLoader<K, V> keysAsValuesAsync(List<List<K>> loadCalls, Duration delay) {
-        return keys -> CompletableFuture.supplyAsync(() -> {
-            snooze(delay.toMillis());
-            List<K> ks = new ArrayList<>(keys);
-            loadCalls.add(ks);
-            @SuppressWarnings("unchecked")
-            List<V> values = keys.stream()
-                    .map(k -> (V) k)
-                    .collect(toList());
-            return values;
-        });
-    }
-
     public static <K, V> DataLoader<K, V> idLoader() {
         return idLoader(null, new ArrayList<>());
     }
 
-    public static <K, V> DataLoader<K, V> idLoader(List<List<K>> loadCalls) {
-        return idLoader(null, loadCalls);
-    }
-
     public static <K, V> DataLoader<K, V> idLoader(DataLoaderOptions options, List<List<K>> loadCalls) {
         return DataLoaderFactory.newDataLoader(keysAsValues(loadCalls), options);
-    }
-
-    public static <K, V> DataLoader<K, V> idLoaderAsync(Duration delay) {
-        return idLoaderAsync(null, new ArrayList<>(), delay);
-    }
-
-    public static <K, V> DataLoader<K, V> idLoaderAsync(DataLoaderOptions options, List<List<K>> loadCalls, Duration delay) {
-        return DataLoaderFactory.newDataLoader(keysAsValuesAsync(loadCalls, delay), options);
     }
 
     public static Collection<Integer> listFrom(int i, int max) {

--- a/src/test/java/org/dataloader/fixtures/parameterized/ListDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/ListDataLoaderFactory.java
@@ -4,9 +4,11 @@ import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 import org.dataloader.fixtures.TestKit;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -19,6 +21,15 @@ public class ListDataLoaderFactory implements TestDataLoaderFactory {
             loadCalls.add(new ArrayList<>(keys));
             return completedFuture(keys);
         }, options);
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoaderDelayed(DataLoaderOptions options, List<Collection<K>> loadCalls, Duration delay) {
+        return newDataLoader(keys -> CompletableFuture.supplyAsync(() -> {
+            TestKit.snooze(delay.toMillis());
+            loadCalls.add(new ArrayList<>(keys));
+            return keys;
+        }));
     }
 
     @Override

--- a/src/test/java/org/dataloader/fixtures/parameterized/MappedDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/MappedDataLoaderFactory.java
@@ -2,15 +2,19 @@ package org.dataloader.fixtures.parameterized;
 
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
+import org.dataloader.fixtures.TestKit;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.DataLoaderFactory.newMappedDataLoader;
 import static org.dataloader.fixtures.TestKit.futureError;
 
@@ -25,6 +29,18 @@ public class MappedDataLoaderFactory implements TestDataLoaderFactory {
             keys.forEach(k -> map.put(k, k));
             return completedFuture(map);
         }, options);
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoaderDelayed(
+            DataLoaderOptions options, List<Collection<K>> loadCalls, Duration delay) {
+        return newMappedDataLoader(keys -> CompletableFuture.supplyAsync(() -> {
+            TestKit.snooze(delay.toMillis());
+            loadCalls.add(new ArrayList<>(keys));
+            Map<K, K> map = new HashMap<>();
+            keys.forEach(k -> map.put(k, k));
+            return map;
+        }));
     }
 
     @Override

--- a/src/test/java/org/dataloader/fixtures/parameterized/PublisherDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/PublisherDataLoaderFactory.java
@@ -3,13 +3,17 @@ package org.dataloader.fixtures.parameterized;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 import org.dataloader.Try;
+import org.dataloader.fixtures.TestKit;
 import reactor.core.publisher.Flux;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
+import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.DataLoaderFactory.newPublisherDataLoader;
 import static org.dataloader.DataLoaderFactory.newPublisherDataLoaderWithTry;
 
@@ -21,6 +25,17 @@ public class PublisherDataLoaderFactory implements TestDataLoaderFactory, TestRe
         return newPublisherDataLoader((keys, subscriber) -> {
             loadCalls.add(new ArrayList<>(keys));
             Flux.fromIterable(keys).subscribe(subscriber);
+        }, options);
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoaderDelayed(DataLoaderOptions options, List<Collection<K>> loadCalls, Duration delay) {
+        return newPublisherDataLoader((keys, subscriber) -> {
+            CompletableFuture.runAsync(() -> {
+                TestKit.snooze(delay.toMillis());
+                loadCalls.add(new ArrayList<>(keys));
+                Flux.fromIterable(keys).subscribe(subscriber);
+            });
         }, options);
     }
 

--- a/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
@@ -6,20 +6,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.util.stream.Stream;
 
 public class TestDataLoaderFactories {
+
     public static Stream<Arguments> get() {
         return Stream.of(
             Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
             Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory())),
             Arguments.of(Named.of("Publisher DataLoader", new PublisherDataLoaderFactory())),
             Arguments.of(Named.of("Mapped Publisher DataLoader", new MappedPublisherDataLoaderFactory()))
-        );
-    }
-
-    // TODO: Remove in favour of #get when ValueCache supports Publisher Factories.
-    public static Stream<Arguments> getWithoutPublisher() {
-        return Stream.of(
-            Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
-            Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory()))
         );
     }
 }

--- a/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
@@ -1,0 +1,25 @@
+package org.dataloader.fixtures.parameterized;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.stream.Stream;
+
+public class TestDataLoaderFactories {
+    public static Stream<Arguments> get() {
+        return Stream.of(
+            Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
+            Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory())),
+            Arguments.of(Named.of("Publisher DataLoader", new PublisherDataLoaderFactory())),
+            Arguments.of(Named.of("Mapped Publisher DataLoader", new MappedPublisherDataLoaderFactory()))
+        );
+    }
+
+    // TODO: Remove in favour of #get when ValueCache supports Publisher Factories.
+    public static Stream<Arguments> getWithoutPublisher() {
+        return Stream.of(
+            Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
+            Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory()))
+        );
+    }
+}

--- a/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactory.java
@@ -3,12 +3,15 @@ package org.dataloader.fixtures.parameterized;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 public interface TestDataLoaderFactory {
     <K> DataLoader<K, K> idLoader(DataLoaderOptions options, List<Collection<K>> loadCalls);
+
+    <K> DataLoader<K, K> idLoaderDelayed(DataLoaderOptions options, List<Collection<K>> loadCalls, Duration delay);
 
     <K> DataLoader<K, K> idLoaderBlowsUps(DataLoaderOptions options, List<Collection<K>> loadCalls);
 
@@ -19,4 +22,17 @@ public interface TestDataLoaderFactory {
     DataLoader<String, String> onlyReturnsNValues(int N, DataLoaderOptions options, ArrayList<Object> loadCalls);
 
     DataLoader<String, String> idLoaderReturnsTooMany(int howManyMore, DataLoaderOptions options, ArrayList<Object> loadCalls);
+
+    // Convenience methods
+
+    default <K> DataLoader<K, K> idLoader(List<Collection<K>> calls) {
+        return idLoader(null, calls);
+    }
+    default <K> DataLoader<K, K> idLoader() {
+        return idLoader(null, new ArrayList<>());
+    }
+
+    default <K> DataLoader<K, K> idLoaderDelayed(Duration delay) {
+        return idLoaderDelayed(null, new ArrayList<>(), delay);
+    }
 }


### PR DESCRIPTION
We resolve two bugs in the interaction between Publisher `DataLoader`s and `ValueCache`s:

- if the value was cached, we complete the corresponding queued futures immediately.
- if the value was _not_ cached, we remember to provide the queued future to the invoker so that the future can eventually be completed.

This is intended to be merged following #171, as this pull request builds of this.