### PR TITLE
Transform support for DataLoaders

### DIFF
--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -25,9 +25,15 @@ import org.dataloader.stats.StatisticsCollector;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.dataloader.impl.Assertions.nonNull;
 
@@ -54,7 +60,6 @@ import static org.dataloader.impl.Assertions.nonNull;
  *
  * @param <K> type parameter indicating the type of the data load keys
  * @param <V> type parameter indicating the type of the data that is returned
- *
  * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
  * @author <a href="https://github.com/bbakerman/">Brad Baker</a>
  */
@@ -65,6 +70,8 @@ public class DataLoader<K, V> {
     private final StatisticsCollector stats;
     private final CacheMap<Object, V> futureCache;
     private final ValueCache<K, V> valueCache;
+    private final DataLoaderOptions options;
+    private final Object batchLoadFunction;
 
     /**
      * Creates new DataLoader with the specified batch loader function and default options
@@ -73,9 +80,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -90,9 +95,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -114,9 +117,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -133,9 +134,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see DataLoaderFactory#newDataLoaderWithTry(BatchLoader)
      * @deprecated use {@link DataLoaderFactory} instead
      */
@@ -151,9 +150,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -168,9 +165,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -192,9 +187,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -211,9 +204,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see DataLoaderFactory#newDataLoaderWithTry(BatchLoader)
      * @deprecated use {@link DataLoaderFactory} instead
      */
@@ -229,9 +220,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -246,9 +235,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -271,9 +258,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -290,9 +275,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see DataLoaderFactory#newDataLoaderWithTry(BatchLoader)
      * @deprecated use {@link DataLoaderFactory} instead
      */
@@ -308,9 +291,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -325,9 +306,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -349,9 +328,7 @@ public class DataLoader<K, V> {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -368,9 +345,7 @@ public class DataLoader<K, V> {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see DataLoaderFactory#newDataLoaderWithTry(BatchLoader)
      * @deprecated use {@link DataLoaderFactory} instead
      */
@@ -383,7 +358,6 @@ public class DataLoader<K, V> {
      * Creates a new data loader with the provided batch load function, and default options.
      *
      * @param batchLoadFunction the batch load function to use
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -396,7 +370,6 @@ public class DataLoader<K, V> {
      *
      * @param batchLoadFunction the batch load function to use
      * @param options           the batch load options
-     *
      * @deprecated use {@link DataLoaderFactory} instead
      */
     @Deprecated
@@ -416,6 +389,8 @@ public class DataLoader<K, V> {
         this.valueCache = determineValueCache(loaderOptions);
         // order of keys matter in data loader
         this.stats = nonNull(loaderOptions.getStatisticsCollector());
+        this.batchLoadFunction = nonNull(batchLoadFunction);
+        this.options = loaderOptions;
 
         this.helper = new DataLoaderHelper<>(this, batchLoadFunction, loaderOptions, this.futureCache, this.valueCache, this.stats, clock);
     }
@@ -429,6 +404,32 @@ public class DataLoader<K, V> {
     @SuppressWarnings("unchecked")
     private ValueCache<K, V> determineValueCache(DataLoaderOptions loaderOptions) {
         return (ValueCache<K, V>) loaderOptions.valueCache().orElseGet(ValueCache::defaultValueCache);
+    }
+
+    /**
+     * @return the options used to build this {@link DataLoader}
+     */
+    public DataLoaderOptions getOptions() {
+        return options;
+    }
+
+    /**
+     * @return the batch load interface used to build this {@link DataLoader}
+     */
+    public Object getBatchLoadFunction() {
+        return batchLoadFunction;
+    }
+
+    /**
+     * This allows you to change the current {@link DataLoader} and turn it into a new one
+     *
+     * @param builderConsumer the {@link DataLoaderFactory.Builder} consumer for changing the {@link DataLoader}
+     * @return a newly built {@link DataLoader} instance
+     */
+    public DataLoader<K, V> transform(Consumer<DataLoaderFactory.Builder<K, V>> builderConsumer) {
+        DataLoaderFactory.Builder<K, V> builder = DataLoaderFactory.builder(this);
+        builderConsumer.accept(builder);
+        return builder.build();
     }
 
     /**
@@ -457,7 +458,6 @@ public class DataLoader<K, V> {
      * and returned from cache).
      *
      * @param key the key to load
-     *
      * @return the future of the value
      */
     public CompletableFuture<V> load(K key) {
@@ -475,7 +475,6 @@ public class DataLoader<K, V> {
      * NOTE : This will NOT cause a data load to happen. You must call {@link #load(Object)} for that to happen.
      *
      * @param key the key to check
-     *
      * @return an Optional to the future of the value
      */
     public Optional<CompletableFuture<V>> getIfPresent(K key) {
@@ -494,7 +493,6 @@ public class DataLoader<K, V> {
      * NOTE : This will NOT cause a data load to happen.  You must call {@link #load(Object)} for that to happen.
      *
      * @param key the key to check
-     *
      * @return an Optional to the future of the value
      */
     public Optional<CompletableFuture<V>> getIfCompleted(K key) {
@@ -514,7 +512,6 @@ public class DataLoader<K, V> {
      *
      * @param key        the key to load
      * @param keyContext a context object that is specific to this key
-     *
      * @return the future of the value
      */
     public CompletableFuture<V> load(K key, Object keyContext) {
@@ -530,7 +527,6 @@ public class DataLoader<K, V> {
      * and returned from cache).
      *
      * @param keys the list of keys to load
-     *
      * @return the composite future of the list of values
      */
     public CompletableFuture<List<V>> loadMany(List<K> keys) {
@@ -550,7 +546,6 @@ public class DataLoader<K, V> {
      *
      * @param keys        the list of keys to load
      * @param keyContexts the list of key calling context objects
-     *
      * @return the composite future of the list of values
      */
     public CompletableFuture<List<V>> loadMany(List<K> keys, List<Object> keyContexts) {
@@ -583,7 +578,6 @@ public class DataLoader<K, V> {
      * {@link org.dataloader.MappedBatchLoaderWithContext} to help retrieve data.
      *
      * @param keysAndContexts the map of keys to their respective contexts
-     *
      * @return the composite future of the map of keys and values
      */
     public CompletableFuture<Map<K, V>> loadMany(Map<K, ?> keysAndContexts) {
@@ -656,7 +650,6 @@ public class DataLoader<K, V> {
      * on the next load request.
      *
      * @param key the key to remove
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> clear(K key) {
@@ -670,7 +663,6 @@ public class DataLoader<K, V> {
      *
      * @param key     the key to remove
      * @param handler a handler that will be called after the async remote clear completes
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> clear(K key, BiConsumer<Void, Throwable> handler) {
@@ -696,7 +688,6 @@ public class DataLoader<K, V> {
      * Clears the entire cache map of the loader, and of the cached value store.
      *
      * @param handler a handler that will be called after the async remote clear all completes
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> clearAll(BiConsumer<Void, Throwable> handler) {
@@ -714,7 +705,6 @@ public class DataLoader<K, V> {
      *
      * @param key   the key
      * @param value the value
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> prime(K key, V value) {
@@ -726,7 +716,6 @@ public class DataLoader<K, V> {
      *
      * @param key   the key
      * @param error the exception to prime instead of a value
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> prime(K key, Exception error) {
@@ -740,7 +729,6 @@ public class DataLoader<K, V> {
      *
      * @param key   the key
      * @param value the value
-     *
      * @return the data loader for fluent coding
      */
     public DataLoader<K, V> prime(K key, CompletableFuture<V> value) {
@@ -760,7 +748,6 @@ public class DataLoader<K, V> {
      * If no cache key function is present in {@link DataLoaderOptions}, then the returned value equals the input key.
      *
      * @param key the input key
-     *
      * @return the cache key after the input is transformed with the cache key function
      */
     public Object getCacheKey(K key) {
@@ -779,6 +766,7 @@ public class DataLoader<K, V> {
 
     /**
      * Gets the cacheMap associated with this data loader passed in via {@link DataLoaderOptions#cacheMap()}
+     *
      * @return the cacheMap of this data loader
      */
     public CacheMap<Object, V> getCacheMap() {
@@ -788,6 +776,7 @@ public class DataLoader<K, V> {
 
     /**
      * Gets the valueCache associated with this data loader passed in via {@link DataLoaderOptions#valueCache()}
+     *
      * @return the valueCache of this data loader
      */
     public ValueCache<K, V> getValueCache() {

--- a/src/main/java/org/dataloader/DataLoaderFactory.java
+++ b/src/main/java/org/dataloader/DataLoaderFactory.java
@@ -16,7 +16,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoader<K, V> batchLoadFunction) {
@@ -30,7 +29,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -51,7 +49,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoader<K, Try<V>> batchLoadFunction) {
@@ -67,9 +64,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -83,7 +78,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoaderWithContext<K, V> batchLoadFunction) {
@@ -97,7 +91,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -118,7 +111,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoaderWithContext<K, Try<V>> batchLoadFunction) {
@@ -134,9 +126,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -150,7 +140,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoader<K, V> batchLoadFunction) {
@@ -164,7 +153,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -186,7 +174,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoader<K, Try<V>> batchLoadFunction) {
@@ -202,9 +189,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -218,7 +203,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoaderWithContext<K, V> batchLoadFunction) {
@@ -232,7 +216,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -253,7 +236,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction) {
@@ -269,9 +251,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -285,7 +265,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisher<K, V> batchLoadFunction) {
@@ -299,7 +278,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -320,7 +298,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisher<K, Try<V>> batchLoadFunction) {
@@ -336,9 +313,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -352,7 +327,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisherWithContext<K, V> batchLoadFunction) {
@@ -366,7 +340,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -387,7 +360,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisherWithContext<K, Try<V>> batchLoadFunction) {
@@ -403,9 +375,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newPublisherDataLoaderWithTry(BatchPublisher)
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -419,7 +389,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisher<K, V> batchLoadFunction) {
@@ -433,7 +402,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -454,7 +422,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisher<K, Try<V>> batchLoadFunction) {
@@ -470,9 +437,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -486,7 +451,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisherWithContext<K, V> batchLoadFunction) {
@@ -500,7 +464,6 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
@@ -521,7 +484,6 @@ public class DataLoaderFactory {
      * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction) {
@@ -537,9 +499,7 @@ public class DataLoaderFactory {
      * @param options           the options to use
      * @param <K>               the key type
      * @param <V>               the value type
-     *
      * @return a new DataLoader
-     *
      * @see #newMappedPublisherDataLoaderWithTry(MappedBatchPublisher)
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
@@ -549,4 +509,61 @@ public class DataLoaderFactory {
     static <K, V> DataLoader<K, V> mkDataLoader(Object batchLoadFunction, DataLoaderOptions options) {
         return new DataLoader<>(batchLoadFunction, options);
     }
+
+    /**
+     * Return a new {@link Builder} of a data loader.
+     *
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return a new {@link Builder} of a data loader
+     */
+    public static <K, V> Builder<K, V> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Return a new {@link Builder} of a data loader using the specified one as a template.
+     *
+     * @param <K>        the key type
+     * @param <V>        the value type
+     * @param dataLoader the {@link DataLoader} to copy values from into the builder
+     * @return a new {@link Builder} of a data loader
+     */
+    public static <K, V> Builder<K, V> builder(DataLoader<K, V> dataLoader) {
+        return new Builder<>(dataLoader);
+    }
+
+    /**
+     * A builder of {@link DataLoader}s
+     *
+     * @param <K> the key type
+     * @param <V> the value type
+     */
+    public static class Builder<K, V> {
+        Object batchLoadFunction;
+        DataLoaderOptions options = DataLoaderOptions.newOptions();
+
+        Builder() {
+        }
+
+        Builder(DataLoader<?, ?> dataLoader) {
+            this.batchLoadFunction = dataLoader.getBatchLoadFunction();
+            this.options = dataLoader.getOptions();
+        }
+
+        public Builder<K, V> batchLoadFunction(Object batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> options(DataLoaderOptions options) {
+            this.options = options;
+            return this;
+        }
+
+        DataLoader<K, V> build() {
+            return mkDataLoader(batchLoadFunction, options);
+        }
+    }
 }
+

--- a/src/test/java/org/dataloader/DataLoaderBuilderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBuilderTest.java
@@ -1,0 +1,64 @@
+package org.dataloader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class DataLoaderBuilderTest {
+
+    BatchLoader<String, Object> batchLoader1 = keys -> null;
+
+    BatchLoader<String, Object> batchLoader2 = keys -> null;
+
+    DataLoaderOptions defaultOptions = DataLoaderOptions.newOptions();
+    DataLoaderOptions differentOptions = DataLoaderOptions.newOptions().setCachingEnabled(false);
+
+    @Test
+    void canBuildNewDataLoaders() {
+        DataLoaderFactory.Builder<String, Object> builder = DataLoaderFactory.builder();
+        builder.options(differentOptions);
+        builder.batchLoadFunction(batchLoader1);
+        DataLoader<String, Object> dataLoader = builder.build();
+
+        assertThat(dataLoader.getOptions(), equalTo(differentOptions));
+        assertThat(dataLoader.getBatchLoadFunction(), equalTo(batchLoader1));
+        //
+        // and we can copy ok
+        //
+        builder = DataLoaderFactory.builder(dataLoader);
+        dataLoader = builder.build();
+
+        assertThat(dataLoader.getOptions(), equalTo(differentOptions));
+        assertThat(dataLoader.getBatchLoadFunction(), equalTo(batchLoader1));
+        //
+        // and we can copy and transform ok
+        //
+        builder = DataLoaderFactory.builder(dataLoader);
+        builder.options(defaultOptions);
+        builder.batchLoadFunction(batchLoader2);
+        dataLoader = builder.build();
+
+        assertThat(dataLoader.getOptions(), equalTo(defaultOptions));
+        assertThat(dataLoader.getBatchLoadFunction(), equalTo(batchLoader2));
+    }
+
+    @Test
+    void theDataLoaderCanTransform() {
+        DataLoader<String, Object> dataLoader1 = DataLoaderFactory.newDataLoader(batchLoader1, defaultOptions);
+        assertThat(dataLoader1.getOptions(), equalTo(defaultOptions));
+        assertThat(dataLoader1.getBatchLoadFunction(), equalTo(batchLoader1));
+        //
+        // we can transform the data loader
+        //
+        DataLoader<String, Object> dataLoader2 = dataLoader1.transform(it -> {
+            it.options(differentOptions);
+            it.batchLoadFunction(batchLoader2);
+        });
+
+        assertThat(dataLoader2, not(equalTo(dataLoader1)));
+        assertThat(dataLoader2.getOptions(), equalTo(differentOptions));
+        assertThat(dataLoader2.getBatchLoadFunction(), equalTo(batchLoader2));
+    }
+}


### PR DESCRIPTION

This adds support for a builder pattern in DataLoaders

The idea is so we can "transform" and existing dataloader and change its values

```
        DataLoader<String, Object> dataLoader2 = dataLoader1.transform(it -> {
            it.options(differentOptions);
            it.batchLoadFunction(batchLoader2);
        });
```

This PR is a setup PR to allow for "instrumentation" of DataLoaders.  The Spring team have asked for this to allow them to "time" the batch load functions etc.. and they might not have built the data loaders at request time

This PR is small pre-req to that