### PR TITLE
Added support for a delegating data loader

### DIFF
--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -21,6 +21,7 @@ import org.dataloader.annotations.VisibleForTesting;
 import org.dataloader.impl.CompletableFutureKit;
 import org.dataloader.stats.Statistics;
 import org.dataloader.stats.StatisticsCollector;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -517,8 +518,8 @@ public class DataLoader<K, V> {
      * @param keyContext a context object that is specific to this key
      * @return the future of the value
      */
-    public CompletableFuture<V> load(K key, Object keyContext) {
-        return helper.load(key, keyContext);
+    public CompletableFuture<V> load(@NonNull K key, @Nullable Object keyContext) {
+        return helper.load(nonNull(key), keyContext);
     }
 
     /**

--- a/src/main/java/org/dataloader/DelegatingDataLoader.java
+++ b/src/main/java/org/dataloader/DelegatingDataLoader.java
@@ -2,6 +2,9 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicApi;
 import org.dataloader.stats.Statistics;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -19,6 +22,7 @@ import java.util.function.Consumer;
  * @param <V> type parameter indicating the type of the data that is returned
  */
 @PublicApi
+@NullMarked
 public class DelegatingDataLoader<K, V> extends DataLoader<K, V> {
 
     protected final DataLoader<K, V> delegate;
@@ -57,7 +61,7 @@ public class DelegatingDataLoader<K, V> extends DataLoader<K, V> {
      * @return the future of the value
      */
     @Override
-    public CompletableFuture<V> load(K key, Object keyContext) {
+    public CompletableFuture<V> load(@NonNull K key, @Nullable Object keyContext) {
         return delegate.load(key, keyContext);
     }
 

--- a/src/main/java/org/dataloader/DelegatingDataLoader.java
+++ b/src/main/java/org/dataloader/DelegatingDataLoader.java
@@ -22,18 +22,16 @@ import java.util.function.Consumer;
  * method.
  * <p>
  * For example the following allows you to change the returned value in some way :
- * <pre>
- * {@code
- *         DataLoader<String, String> rawLoader = createDataLoader();
- *         DelegatingDataLoader<String, String> delegatingDataLoader = new DelegatingDataLoader<>(rawLoader) {
- *             @Override
- *             public CompletableFuture<String> load(@NonNull String key, @Nullable Object keyContext) {
- *                 CompletableFuture<String> cf = super.load(key, keyContext);
- *                 return cf.thenApply(v -> "|" + v + "|");
- *             }
- *         };
- * }
- * </pre>
+ * <pre>{@code
+ * DataLoader<String, String> rawLoader = createDataLoader();
+ * DelegatingDataLoader<String, String> delegatingDataLoader = new DelegatingDataLoader<>(rawLoader) {
+ *    public CompletableFuture<String> load(@NonNull String key, @Nullable Object keyContext) {
+ *       CompletableFuture<String> cf = super.load(key, keyContext);
+ *       return cf.thenApply(v -> "|" + v + "|");
+ *    }
+ *};
+ *}</pre>
+ *
  * @param <K> type parameter indicating the type of the data load keys
  * @param <V> type parameter indicating the type of the data that is returned
  */

--- a/src/main/java/org/dataloader/DelegatingDataLoader.java
+++ b/src/main/java/org/dataloader/DelegatingDataLoader.java
@@ -1,0 +1,171 @@
+package org.dataloader;
+
+import org.dataloader.annotations.PublicApi;
+import org.dataloader.stats.Statistics;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * This delegating {@link DataLoader} makes it easier to create wrappers of {@link DataLoader}s in case you want to change how
+ * values are returned for example
+ *
+ * @param <K> type parameter indicating the type of the data load keys
+ * @param <V> type parameter indicating the type of the data that is returned
+ */
+@PublicApi
+public class DelegatingDataLoader<K, V> extends DataLoader<K, V> {
+
+    protected final DataLoader<K, V> delegate;
+
+    /**
+     * This can be called to unwrap a given {@link DataLoader} such that if it's a {@link DelegatingDataLoader} the underlying
+     * {@link DataLoader} is returned otherwise it's just passed in data loader
+     *
+     * @param dataLoader the dataLoader to unwrap
+     * @param <K>        type parameter indicating the type of the data load keys
+     * @param <V>        type parameter indicating the type of the data that is returned
+     * @return the delegate dataLoader OR just this current one if it's not wrapped
+     */
+    public static <K, V> DataLoader<K, V> unwrap(DataLoader<K, V> dataLoader) {
+        if (dataLoader instanceof DelegatingDataLoader) {
+            return ((DelegatingDataLoader<K, V>) dataLoader).getDelegate();
+        }
+        return dataLoader;
+    }
+
+    public DelegatingDataLoader(DataLoader<K, V> delegate) {
+        super(delegate.getBatchLoadFunction(), delegate.getOptions());
+        this.delegate = delegate;
+    }
+
+    public DataLoader<K, V> getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * The {@link DataLoader#load(Object)} and {@link DataLoader#loadMany(List)} type methods all call back
+     * to the {@link DataLoader#load(Object, Object)} and hence we don't override them.
+     *
+     * @param key        the key to load
+     * @param keyContext a context object that is specific to this key
+     * @return the future of the value
+     */
+    @Override
+    public CompletableFuture<V> load(K key, Object keyContext) {
+        return delegate.load(key, keyContext);
+    }
+
+
+    @Override
+    public DataLoader<K, V> transform(Consumer<DataLoaderFactory.Builder<K, V>> builderConsumer) {
+        return delegate.transform(builderConsumer);
+    }
+
+    @Override
+    public Instant getLastDispatchTime() {
+        return delegate.getLastDispatchTime();
+    }
+
+    @Override
+    public Duration getTimeSinceDispatch() {
+        return delegate.getTimeSinceDispatch();
+    }
+
+    @Override
+    public Optional<CompletableFuture<V>> getIfPresent(K key) {
+        return delegate.getIfPresent(key);
+    }
+
+    @Override
+    public Optional<CompletableFuture<V>> getIfCompleted(K key) {
+        return delegate.getIfCompleted(key);
+    }
+
+    @Override
+    public CompletableFuture<List<V>> dispatch() {
+        return delegate.dispatch();
+    }
+
+    @Override
+    public DispatchResult<V> dispatchWithCounts() {
+        return delegate.dispatchWithCounts();
+    }
+
+    @Override
+    public List<V> dispatchAndJoin() {
+        return delegate.dispatchAndJoin();
+    }
+
+    @Override
+    public int dispatchDepth() {
+        return delegate.dispatchDepth();
+    }
+
+    @Override
+    public Object getCacheKey(K key) {
+        return delegate.getCacheKey(key);
+    }
+
+    @Override
+    public Statistics getStatistics() {
+        return delegate.getStatistics();
+    }
+
+    @Override
+    public CacheMap<Object, V> getCacheMap() {
+        return delegate.getCacheMap();
+    }
+
+    @Override
+    public ValueCache<K, V> getValueCache() {
+        return delegate.getValueCache();
+    }
+
+    @Override
+    public DataLoader<K, V> clear(K key) {
+        delegate.clear(key);
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> clear(K key, BiConsumer<Void, Throwable> handler) {
+        delegate.clear(key, handler);
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> clearAll() {
+        delegate.clearAll();
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> clearAll(BiConsumer<Void, Throwable> handler) {
+        delegate.clearAll(handler);
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> prime(K key, V value) {
+        delegate.prime(key, value);
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> prime(K key, Exception error) {
+        delegate.prime(key, error);
+        return this;
+    }
+
+    @Override
+    public DataLoader<K, V> prime(K key, CompletableFuture<V> value) {
+        delegate.prime(key, value);
+        return this;
+    }
+}

--- a/src/main/java/org/dataloader/DelegatingDataLoader.java
+++ b/src/main/java/org/dataloader/DelegatingDataLoader.java
@@ -16,8 +16,24 @@ import java.util.function.Consumer;
 
 /**
  * This delegating {@link DataLoader} makes it easier to create wrappers of {@link DataLoader}s in case you want to change how
- * values are returned for example
- *
+ * values are returned for example.
+ * <p>
+ * The most common way would be to make a new {@link DelegatingDataLoader} subclass that overloads the {@link DelegatingDataLoader#load(Object, Object)}
+ * method.
+ * <p>
+ * For example the following allows you to change the returned value in some way :
+ * <pre>
+ * {@code
+ *         DataLoader<String, String> rawLoader = createDataLoader();
+ *         DelegatingDataLoader<String, String> delegatingDataLoader = new DelegatingDataLoader<>(rawLoader) {
+ *             @Override
+ *             public CompletableFuture<String> load(@NonNull String key, @Nullable Object keyContext) {
+ *                 CompletableFuture<String> cf = super.load(key, keyContext);
+ *                 return cf.thenApply(v -> "|" + v + "|");
+ *             }
+ *         };
+ * }
+ * </pre>
  * @param <K> type parameter indicating the type of the data load keys
  * @param <V> type parameter indicating the type of the data that is returned
  */
@@ -64,7 +80,6 @@ public class DelegatingDataLoader<K, V> extends DataLoader<K, V> {
     public CompletableFuture<V> load(@NonNull K key, @Nullable Object keyContext) {
         return delegate.load(key, keyContext);
     }
-
 
     @Override
     public DataLoader<K, V> transform(Consumer<DataLoaderFactory.Builder<K, V>> builderConsumer) {

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -785,7 +785,7 @@ public class DataLoaderTest {
         assertThat(future1.get(), equalTo("A"));
         assertThat(future2.get(), equalTo("B"));
         assertThat(future3.get(), equalTo("A"));
-        if (factory instanceof MappedDataLoaderFactory || factory instanceof MappedPublisherDataLoaderFactory) {
+        if (factory.unwrap() instanceof MappedDataLoaderFactory || factory.unwrap() instanceof MappedPublisherDataLoaderFactory) {
             assertThat(loadCalls, equalTo(singletonList(asList("A", "B"))));
         } else {
             assertThat(loadCalls, equalTo(singletonList(asList("A", "B", "A"))));
@@ -1152,12 +1152,12 @@ public class DataLoaderTest {
 
         await().atMost(Duration.FIVE_SECONDS).until(() -> areAllDone(cf1, cf2, cf3, cf4));
 
-        if (factory instanceof ListDataLoaderFactory) {
+        if (factory.unwrap() instanceof ListDataLoaderFactory) {
             assertThat(cause(cf1), instanceOf(DataLoaderAssertionException.class));
             assertThat(cause(cf2), instanceOf(DataLoaderAssertionException.class));
             assertThat(cause(cf3), instanceOf(DataLoaderAssertionException.class));
             assertThat(cause(cf4), instanceOf(DataLoaderAssertionException.class));
-        } else if (factory instanceof PublisherDataLoaderFactory) {
+        } else if (factory.unwrap() instanceof PublisherDataLoaderFactory) {
             // some have completed progressively but the other never did
             assertThat(cf1.join(), equalTo("A"));
             assertThat(cf2.join(), equalTo("B"));
@@ -1187,7 +1187,7 @@ public class DataLoaderTest {
         await().atMost(Duration.FIVE_SECONDS).until(() -> areAllDone(cf1, cf2, cf3, cf4));
 
 
-        if (factory instanceof ListDataLoaderFactory) {
+        if (factory.unwrap() instanceof ListDataLoaderFactory) {
             assertThat(cause(cf1), instanceOf(DataLoaderAssertionException.class));
             assertThat(cause(cf2), instanceOf(DataLoaderAssertionException.class));
             assertThat(cause(cf3), instanceOf(DataLoaderAssertionException.class));

--- a/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
+++ b/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
@@ -1,6 +1,8 @@
 package org.dataloader;
 
 import org.dataloader.fixtures.TestKit;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -31,7 +33,7 @@ public class DelegatingDataLoaderTest {
         DataLoader<String, String> rawLoader = TestKit.idLoader();
         DelegatingDataLoader<String, String> delegatingDataLoader = new DelegatingDataLoader<>(rawLoader) {
             @Override
-            public CompletableFuture<String> load(String key, Object keyContext) {
+            public CompletableFuture<String> load(@NonNull String key, @Nullable Object keyContext) {
                 CompletableFuture<String> cf = super.load(key, keyContext);
                 return cf.thenApply(v -> "|" + v + "|");
             }

--- a/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
+++ b/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
@@ -1,6 +1,7 @@
 package org.dataloader;
 
 import org.dataloader.fixtures.TestKit;
+import org.dataloader.fixtures.parameterized.DelegatingDataLoaderFactory;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * There are WAY more tests via the {@link org.dataloader.fixtures.parameterized.DelegatingDataLoaderFactory}
+ * There are WAY more tests via the {@link DelegatingDataLoaderFactory}
  * parameterized tests.  All the basic {@link DataLoader} tests pass when wrapped in a {@link DelegatingDataLoader}
  */
 public class DelegatingDataLoaderTest {

--- a/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
+++ b/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
@@ -1,0 +1,61 @@
+package org.dataloader;
+
+import org.dataloader.fixtures.TestKit;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * There are WAY more tests via the {@link org.dataloader.fixtures.parameterized.DelegatingDataLoaderFactory}
+ * parameterized tests.  All the basic {@link DataLoader} tests pass when wrapped in a {@link DelegatingDataLoader}
+ */
+public class DelegatingDataLoaderTest {
+
+    @Test
+    void canUnwrapDataLoaders() {
+        DataLoader<Object, Object> rawLoader = TestKit.idLoader();
+        DataLoader<Object, Object> delegateLoader = new DelegatingDataLoader<>(rawLoader);
+
+        assertThat(DelegatingDataLoader.unwrap(rawLoader), is(rawLoader));
+        assertThat(DelegatingDataLoader.unwrap(delegateLoader), is(rawLoader));
+    }
+
+    @Test
+    void canCreateAClassOk() {
+        DataLoader<String, String> rawLoader = TestKit.idLoader();
+        DelegatingDataLoader<String, String> delegatingDataLoader = new DelegatingDataLoader<>(rawLoader) {
+            @Override
+            public CompletableFuture<String> load(String key, Object keyContext) {
+                CompletableFuture<String> cf = super.load(key, keyContext);
+                return cf.thenApply(v -> "|" + v + "|");
+            }
+        };
+
+        assertThat(delegatingDataLoader.getDelegate(), is(rawLoader));
+
+
+        CompletableFuture<String> cfA = delegatingDataLoader.load("A");
+        CompletableFuture<String> cfB = delegatingDataLoader.load("B");
+        CompletableFuture<List<String>> cfCD = delegatingDataLoader.loadMany(List.of("C", "D"));
+
+        CompletableFuture<List<String>> dispatch = delegatingDataLoader.dispatch();
+
+        await().until(dispatch::isDone);
+
+        assertThat(cfA.join(), equalTo("|A|"));
+        assertThat(cfB.join(), equalTo("|B|"));
+        assertThat(cfCD.join(), equalTo(List.of("|C|", "|D|")));
+
+        assertThat(delegatingDataLoader.getIfPresent("A").isEmpty(), equalTo(false));
+        assertThat(delegatingDataLoader.getIfPresent("X").isEmpty(), equalTo(true));
+
+        assertThat(delegatingDataLoader.getIfCompleted("A").isEmpty(), equalTo(false));
+        assertThat(delegatingDataLoader.getIfCompleted("X").isEmpty(), equalTo(true));
+    }
+}

--- a/src/test/java/org/dataloader/fixtures/parameterized/DelegatingDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/DelegatingDataLoaderFactory.java
@@ -1,0 +1,71 @@
+package org.dataloader.fixtures.parameterized;
+
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+import org.dataloader.DelegatingDataLoader;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class DelegatingDataLoaderFactory implements TestDataLoaderFactory {
+    // its delegates all the way down to the turtles
+    private final TestDataLoaderFactory delegateFactory;
+
+    public DelegatingDataLoaderFactory(TestDataLoaderFactory delegateFactory) {
+        this.delegateFactory = delegateFactory;
+    }
+
+    @Override
+    public String toString() {
+        return "DelegatingDataLoaderFactory{" +
+                "delegateFactory=" + delegateFactory +
+                '}';
+    }
+
+    @Override
+    public TestDataLoaderFactory unwrap() {
+        return delegateFactory.unwrap();
+    }
+
+    private <K, V> DataLoader<K, V> mkDelegateDataLoader(DataLoader<K, V> dataLoader) {
+        return new DelegatingDataLoader<>(dataLoader);
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoader(DataLoaderOptions options, List<Collection<K>> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.idLoader(options, loadCalls));
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoaderDelayed(DataLoaderOptions options, List<Collection<K>> loadCalls, Duration delay) {
+        return mkDelegateDataLoader(delegateFactory.idLoaderDelayed(options, loadCalls, delay));
+    }
+
+    @Override
+    public <K> DataLoader<K, K> idLoaderBlowsUps(
+            DataLoaderOptions options, List<Collection<K>> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.idLoaderBlowsUps(options, loadCalls));
+    }
+
+    @Override
+    public <K> DataLoader<K, Object> idLoaderAllExceptions(DataLoaderOptions options, List<Collection<K>> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.idLoaderAllExceptions(options, loadCalls));
+    }
+
+    @Override
+    public DataLoader<Integer, Object> idLoaderOddEvenExceptions(DataLoaderOptions options, List<Collection<Integer>> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.idLoaderOddEvenExceptions(options, loadCalls));
+    }
+
+    @Override
+    public DataLoader<String, String> onlyReturnsNValues(int N, DataLoaderOptions options, ArrayList<Object> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.onlyReturnsNValues(N, options, loadCalls));
+    }
+
+    @Override
+    public DataLoader<String, String> idLoaderReturnsTooMany(int howManyMore, DataLoaderOptions options, ArrayList<Object> loadCalls) {
+        return mkDelegateDataLoader(delegateFactory.idLoaderReturnsTooMany(howManyMore, options, loadCalls));
+    }
+}

--- a/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactories.java
@@ -5,14 +5,21 @@ import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
+@SuppressWarnings("unused")
 public class TestDataLoaderFactories {
 
     public static Stream<Arguments> get() {
         return Stream.of(
-            Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
-            Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory())),
-            Arguments.of(Named.of("Publisher DataLoader", new PublisherDataLoaderFactory())),
-            Arguments.of(Named.of("Mapped Publisher DataLoader", new MappedPublisherDataLoaderFactory()))
+                Arguments.of(Named.of("List DataLoader", new ListDataLoaderFactory())),
+                Arguments.of(Named.of("Mapped DataLoader", new MappedDataLoaderFactory())),
+                Arguments.of(Named.of("Publisher DataLoader", new PublisherDataLoaderFactory())),
+                Arguments.of(Named.of("Mapped Publisher DataLoader", new MappedPublisherDataLoaderFactory())),
+
+                // runs all the above via a DelegateDataLoader
+                Arguments.of(Named.of("Delegate List DataLoader", new DelegatingDataLoaderFactory(new ListDataLoaderFactory()))),
+                Arguments.of(Named.of("Delegate Mapped DataLoader", new DelegatingDataLoaderFactory(new MappedDataLoaderFactory()))),
+                Arguments.of(Named.of("Delegate Publisher DataLoader", new DelegatingDataLoaderFactory(new PublisherDataLoaderFactory()))),
+                Arguments.of(Named.of("Delegate Mapped Publisher DataLoader", new DelegatingDataLoaderFactory(new MappedPublisherDataLoaderFactory())))
         );
     }
 }

--- a/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactory.java
+++ b/src/test/java/org/dataloader/fixtures/parameterized/TestDataLoaderFactory.java
@@ -39,4 +39,8 @@ public interface TestDataLoaderFactory {
     default <K> DataLoader<K, K> idLoaderDelayed(Duration delay) {
         return idLoaderDelayed(null, new ArrayList<>(), delay);
     }
+
+    default TestDataLoaderFactory unwrap() {
+        return this;
+    }
 }


### PR DESCRIPTION
This allows you to more easily wrap a DataLoader.

This uses the wonderful parameterised test factories and hence ALL the current (and future) data loader tests will run with the delegation in place.

This REALLY REALLY proves the delegation works and will continue to work for new tests