### PR TITLE
Remove jcenter reference after sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Gradle users configure the `java-dataloader` dependency in `build.gradle`:
 
 ```
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
jcenter was sunsetted a while ago. Thanks @andimarek for spotting we are still referencing this in the readme!