### PR TITLE
Breaking change - renaming old mutable setXX methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ for the context object.
 
 ```java
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+            .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx()).build();
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -227,7 +227,7 @@ You can gain access to them as a map by key or as the original list of context o
 
 ```java
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+           .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx()).build();
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -433,7 +433,7 @@ However, you can create your own custom future cache and supply it to the data l
 
 ```java
         MyCustomCache customCache = new MyCustomCache();
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withsetCacheMap(customCache);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setCacheMap(customCache).build();
         DataLoaderFactory.newDataLoader(userBatchLoader, options);
 ```
 
@@ -467,7 +467,7 @@ The tests have an example based on [Caffeine](https://github.com/ben-manes/caffe
 In certain uncommon cases, a DataLoader which does not cache may be desirable. 
 
 ```java
-    DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().withCachingEnabled(false));
+    DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().setCachingEnabled(false).build());
 ``` 
 
 Calling the above will ensure that every call to `.load()` will produce a new promise, and requested keys will not be saved in memory.
@@ -533,7 +533,7 @@ Knowing what the behaviour of your data is important for you to understand how e
 You can configure the statistics collector used when you build the data loader
 
 ```java
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setStatisticsCollector(() -> new ThreadLocalStatisticsCollector()).build();
         DataLoader<String,User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader,options);
 
 ```
@@ -780,7 +780,7 @@ You set the `DataLoaderInstrumentation` into the `DataLoaderOptions` at build ti
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withInstrumentation(timingInstrumentation);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setInstrumentation(timingInstrumentation).build();
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
         
 ```

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ for the context object.
 
 ```java
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -227,7 +227,7 @@ You can gain access to them as a map by key or as the original list of context o
 
 ```java
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -433,7 +433,7 @@ However, you can create your own custom future cache and supply it to the data l
 
 ```java
         MyCustomCache customCache = new MyCustomCache();
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setCacheMap(customCache);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withsetCacheMap(customCache);
         DataLoaderFactory.newDataLoader(userBatchLoader, options);
 ```
 
@@ -467,7 +467,7 @@ The tests have an example based on [Caffeine](https://github.com/ben-manes/caffe
 In certain uncommon cases, a DataLoader which does not cache may be desirable. 
 
 ```java
-    DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().setCachingEnabled(false));
+    DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().withCachingEnabled(false));
 ``` 
 
 Calling the above will ensure that every call to `.load()` will produce a new promise, and requested keys will not be saved in memory.
@@ -533,7 +533,7 @@ Knowing what the behaviour of your data is important for you to understand how e
 You can configure the statistics collector used when you build the data loader
 
 ```java
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
         DataLoader<String,User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader,options);
 
 ```
@@ -780,7 +780,7 @@ You set the `DataLoaderInstrumentation` into the `DataLoaderOptions` at build ti
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setInstrumentation(timingInstrumentation);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withInstrumentation(timingInstrumentation);
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
         
 ```

--- a/src/main/java/org/dataloader/DataLoaderFactory.java
+++ b/src/main/java/org/dataloader/DataLoaderFactory.java
@@ -542,7 +542,7 @@ public class DataLoaderFactory {
      */
     public static class Builder<K, V> {
         Object batchLoadFunction;
-        DataLoaderOptions options = DataLoaderOptions.newOptions();
+        DataLoaderOptions options = DataLoaderOptions.newDefaultOptions();
 
         Builder() {
         }

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -177,7 +177,7 @@ public class DataLoaderOptions {
      * @param batchingEnabled {@code true} to enable batch loading, {@code false} otherwise
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setBatchingEnabled(boolean batchingEnabled) {
+    public DataLoaderOptions withBatchingEnabled(boolean batchingEnabled) {
         return builder().setBatchingEnabled(batchingEnabled).build();
     }
 
@@ -196,7 +196,7 @@ public class DataLoaderOptions {
      * @param cachingEnabled {@code true} to enable caching, {@code false} otherwise
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setCachingEnabled(boolean cachingEnabled) {
+    public DataLoaderOptions withCachingEnabled(boolean cachingEnabled) {
         return builder().setCachingEnabled(cachingEnabled).build();
     }
 
@@ -220,7 +220,7 @@ public class DataLoaderOptions {
      * @param cachingExceptionsEnabled {@code true} to enable caching exceptional values, {@code false} otherwise
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setCachingExceptionsEnabled(boolean cachingExceptionsEnabled) {
+    public DataLoaderOptions withCachingExceptionsEnabled(boolean cachingExceptionsEnabled) {
         return builder().setCachingExceptionsEnabled(cachingExceptionsEnabled).build();
     }
 
@@ -241,7 +241,7 @@ public class DataLoaderOptions {
      * @param cacheKeyFunction the cache key function to use
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setCacheKeyFunction(CacheKey<?> cacheKeyFunction) {
+    public DataLoaderOptions withCacheKeyFunction(CacheKey<?> cacheKeyFunction) {
         return builder().setCacheKeyFunction(cacheKeyFunction).build();
     }
 
@@ -262,7 +262,7 @@ public class DataLoaderOptions {
      * @param cacheMap the cache map instance
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setCacheMap(CacheMap<?, ?> cacheMap) {
+    public DataLoaderOptions withCacheMap(CacheMap<?, ?> cacheMap) {
         return builder().setCacheMap(cacheMap).build();
     }
 
@@ -283,7 +283,7 @@ public class DataLoaderOptions {
      * @param maxBatchSize the maximum batch size
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setMaxBatchSize(int maxBatchSize) {
+    public DataLoaderOptions withMaxBatchSize(int maxBatchSize) {
         return builder().setMaxBatchSize(maxBatchSize).build();
     }
 
@@ -302,7 +302,7 @@ public class DataLoaderOptions {
      * @param statisticsCollector the statistics collector to use
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setStatisticsCollector(Supplier<StatisticsCollector> statisticsCollector) {
+    public DataLoaderOptions withStatisticsCollector(Supplier<StatisticsCollector> statisticsCollector) {
         return builder().setStatisticsCollector(nonNull(statisticsCollector)).build();
     }
 
@@ -319,7 +319,7 @@ public class DataLoaderOptions {
      * @param contextProvider the batch loader context provider
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setBatchLoaderContextProvider(BatchLoaderContextProvider contextProvider) {
+    public DataLoaderOptions withBatchLoaderContextProvider(BatchLoaderContextProvider contextProvider) {
         return builder().setBatchLoaderContextProvider(nonNull(contextProvider)).build();
     }
 
@@ -340,7 +340,7 @@ public class DataLoaderOptions {
      * @param valueCache the value cache instance
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setValueCache(ValueCache<?, ?> valueCache) {
+    public DataLoaderOptions withValueCache(ValueCache<?, ?> valueCache) {
         return builder().setValueCache(valueCache).build();
     }
 
@@ -357,7 +357,7 @@ public class DataLoaderOptions {
      * @param valueCacheOptions the value cache options
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setValueCacheOptions(ValueCacheOptions valueCacheOptions) {
+    public DataLoaderOptions withValueCacheOptions(ValueCacheOptions valueCacheOptions) {
         return builder().setValueCacheOptions(nonNull(valueCacheOptions)).build();
     }
 
@@ -375,7 +375,7 @@ public class DataLoaderOptions {
      * @param batchLoaderScheduler the scheduler
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setBatchLoaderScheduler(BatchLoaderScheduler batchLoaderScheduler) {
+    public DataLoaderOptions withBatchLoaderScheduler(BatchLoaderScheduler batchLoaderScheduler) {
         return builder().setBatchLoaderScheduler(batchLoaderScheduler).build();
     }
 
@@ -392,7 +392,7 @@ public class DataLoaderOptions {
      * @param instrumentation the new {@link DataLoaderInstrumentation}
      * @return a new data loader options instance for fluent coding
      */
-    public DataLoaderOptions setInstrumentation(DataLoaderInstrumentation instrumentation) {
+    public DataLoaderOptions withInstrumentation(DataLoaderInstrumentation instrumentation) {
         return builder().setInstrumentation(instrumentation).build();
     }
 

--- a/src/main/java/org/dataloader/DataLoaderOptions.java
+++ b/src/main/java/org/dataloader/DataLoaderOptions.java
@@ -90,46 +90,26 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Clones the provided data loader options.
-     *
-     * @param other the other options instance
-     */
-    public DataLoaderOptions(DataLoaderOptions other) {
-        nonNull(other);
-        this.batchingEnabled = other.batchingEnabled;
-        this.cachingEnabled = other.cachingEnabled;
-        this.cachingExceptionsEnabled = other.cachingExceptionsEnabled;
-        this.cacheKeyFunction = other.cacheKeyFunction;
-        this.cacheMap = other.cacheMap;
-        this.valueCache = other.valueCache;
-        this.maxBatchSize = other.maxBatchSize;
-        this.statisticsCollector = other.statisticsCollector;
-        this.environmentProvider = other.environmentProvider;
-        this.valueCacheOptions = other.valueCacheOptions;
-        this.batchLoaderScheduler = other.batchLoaderScheduler;
-        this.instrumentation = other.instrumentation;
-    }
-
-    /**
      * @return a new default data loader options that you can then customize
      */
-    public static DataLoaderOptions newOptions() {
+    public static DataLoaderOptions newDefaultOptions() {
         return new DataLoaderOptions();
     }
 
     /**
-     * @return a new default data loader options {@link Builder} that you can then customize
+     * @return a new default data loader options builder that you can then customize
      */
-    public static DataLoaderOptions.Builder newOptionsBuilder() {
-        return new DataLoaderOptions.Builder();
+    public static DataLoaderOptions.Builder newOptions() {
+        return new Builder();
     }
 
     /**
-     * @param otherOptions the options to copy
-     * @return a new default data loader options {@link Builder} from the specified one that you can then customize
+     * Copies the options into a new builder
+     *
+     * @return a new default data loader options builder that you can then customize
      */
-    public static DataLoaderOptions.Builder newDataLoaderOptions(DataLoaderOptions otherOptions) {
-        return new DataLoaderOptions.Builder(otherOptions);
+    public static DataLoaderOptions.Builder newOptions(DataLoaderOptions otherOptions) {
+        return new Builder(otherOptions);
     }
 
     /**
@@ -139,7 +119,7 @@ public class DataLoaderOptions {
      * @return a new {@link DataLoaderOptions} object
      */
     public DataLoaderOptions transform(Consumer<Builder> builderConsumer) {
-        Builder builder = newDataLoaderOptions(this);
+        Builder builder = new Builder(this);
         builderConsumer.accept(builder);
         return builder.build();
     }
@@ -172,32 +152,12 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets the option that determines whether batch loading is enabled.
-     *
-     * @param batchingEnabled {@code true} to enable batch loading, {@code false} otherwise
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withBatchingEnabled(boolean batchingEnabled) {
-        return builder().setBatchingEnabled(batchingEnabled).build();
-    }
-
-    /**
      * Option that determines whether to use caching of futures (the default), or not.
      *
      * @return {@code true} when caching is enabled, {@code false} otherwise
      */
     public boolean cachingEnabled() {
         return cachingEnabled;
-    }
-
-    /**
-     * Sets the option that determines whether caching is enabled.
-     *
-     * @param cachingEnabled {@code true} to enable caching, {@code false} otherwise
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withCachingEnabled(boolean cachingEnabled) {
-        return builder().setCachingEnabled(cachingEnabled).build();
     }
 
     /**
@@ -215,16 +175,6 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets the option that determines whether exceptional values are cache enabled.
-     *
-     * @param cachingExceptionsEnabled {@code true} to enable caching exceptional values, {@code false} otherwise
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withCachingExceptionsEnabled(boolean cachingExceptionsEnabled) {
-        return builder().setCachingExceptionsEnabled(cachingExceptionsEnabled).build();
-    }
-
-    /**
      * Gets an (optional) function to invoke for creation of the cache key, if caching is enabled.
      * <p>
      * If missing the cache key defaults to the {@code key} type parameter of the data loader of type {@code K}.
@@ -233,16 +183,6 @@ public class DataLoaderOptions {
      */
     public Optional<CacheKey> cacheKeyFunction() {
         return Optional.ofNullable(cacheKeyFunction);
-    }
-
-    /**
-     * Sets the function to use for creating the cache key, if caching is enabled.
-     *
-     * @param cacheKeyFunction the cache key function to use
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withCacheKeyFunction(CacheKey<?> cacheKeyFunction) {
-        return builder().setCacheKeyFunction(cacheKeyFunction).build();
     }
 
     /**
@@ -256,15 +196,6 @@ public class DataLoaderOptions {
         return Optional.ofNullable(cacheMap);
     }
 
-    /**
-     * Sets the cache map implementation to use for caching, if caching is enabled.
-     *
-     * @param cacheMap the cache map instance
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withCacheMap(CacheMap<?, ?> cacheMap) {
-        return builder().setCacheMap(cacheMap).build();
-    }
 
     /**
      * Gets the maximum number of keys that will be presented to the {@link BatchLoader} function
@@ -277,17 +208,6 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets the maximum number of keys that will be presented to the {@link BatchLoader} function
-     * before they are split into multiple class
-     *
-     * @param maxBatchSize the maximum batch size
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withMaxBatchSize(int maxBatchSize) {
-        return builder().setMaxBatchSize(maxBatchSize).build();
-    }
-
-    /**
      * @return the statistics collector to use with these options
      */
     public StatisticsCollector getStatisticsCollector() {
@@ -295,32 +215,10 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets the statistics collector supplier that will be used with these data loader options.  Since it uses
-     * the supplier pattern, you can create a new statistics collector on each call, or you can reuse
-     * a common value
-     *
-     * @param statisticsCollector the statistics collector to use
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withStatisticsCollector(Supplier<StatisticsCollector> statisticsCollector) {
-        return builder().setStatisticsCollector(nonNull(statisticsCollector)).build();
-    }
-
-    /**
      * @return the batch environment provider that will be used to give context to batch load functions
      */
     public BatchLoaderContextProvider getBatchLoaderContextProvider() {
         return environmentProvider;
-    }
-
-    /**
-     * Sets the batch loader environment provider that will be used to give context to batch load functions
-     *
-     * @param contextProvider the batch loader context provider
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withBatchLoaderContextProvider(BatchLoaderContextProvider contextProvider) {
-        return builder().setBatchLoaderContextProvider(nonNull(contextProvider)).build();
     }
 
     /**
@@ -334,31 +232,12 @@ public class DataLoaderOptions {
         return Optional.ofNullable(valueCache);
     }
 
-    /**
-     * Sets the value cache implementation to use for caching values, if caching is enabled.
-     *
-     * @param valueCache the value cache instance
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withValueCache(ValueCache<?, ?> valueCache) {
-        return builder().setValueCache(valueCache).build();
-    }
 
     /**
      * @return the {@link ValueCacheOptions} that control how the {@link ValueCache} will be used
      */
     public ValueCacheOptions getValueCacheOptions() {
         return valueCacheOptions;
-    }
-
-    /**
-     * Sets the {@link ValueCacheOptions} that control how the {@link ValueCache} will be used
-     *
-     * @param valueCacheOptions the value cache options
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withValueCacheOptions(ValueCacheOptions valueCacheOptions) {
-        return builder().setValueCacheOptions(nonNull(valueCacheOptions)).build();
     }
 
     /**
@@ -369,35 +248,10 @@ public class DataLoaderOptions {
     }
 
     /**
-     * Sets in a new {@link BatchLoaderScheduler} that allows the call to a {@link BatchLoader} function to be scheduled
-     * to some future time.
-     *
-     * @param batchLoaderScheduler the scheduler
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withBatchLoaderScheduler(BatchLoaderScheduler batchLoaderScheduler) {
-        return builder().setBatchLoaderScheduler(batchLoaderScheduler).build();
-    }
-
-    /**
      * @return the {@link DataLoaderInstrumentation} to use
      */
     public DataLoaderInstrumentation getInstrumentation() {
         return instrumentation;
-    }
-
-    /**
-     * Sets in a new {@link DataLoaderInstrumentation}
-     *
-     * @param instrumentation the new {@link DataLoaderInstrumentation}
-     * @return a new data loader options instance for fluent coding
-     */
-    public DataLoaderOptions withInstrumentation(DataLoaderInstrumentation instrumentation) {
-        return builder().setInstrumentation(instrumentation).build();
-    }
-
-    private Builder builder() {
-        return new Builder(this);
     }
 
     public static class Builder {
@@ -433,61 +287,137 @@ public class DataLoaderOptions {
             this.instrumentation = other.instrumentation;
         }
 
+        /**
+         * Sets the option that determines whether batch loading is enabled.
+         *
+         * @param batchingEnabled {@code true} to enable batch loading, {@code false} otherwise
+         * @return this builder for fluent coding
+         */
         public Builder setBatchingEnabled(boolean batchingEnabled) {
             this.batchingEnabled = batchingEnabled;
             return this;
         }
 
+        /**
+         * Sets the option that determines whether caching is enabled.
+         *
+         * @param cachingEnabled {@code true} to enable caching, {@code false} otherwise
+         * @return this builder for fluent coding
+         */
         public Builder setCachingEnabled(boolean cachingEnabled) {
             this.cachingEnabled = cachingEnabled;
             return this;
         }
 
+        /**
+         * Sets the option that determines whether exceptional values are cache enabled.
+         *
+         * @param cachingExceptionsEnabled {@code true} to enable caching exceptional values, {@code false} otherwise
+         * @return this builder for fluent coding
+         */
         public Builder setCachingExceptionsEnabled(boolean cachingExceptionsEnabled) {
             this.cachingExceptionsEnabled = cachingExceptionsEnabled;
             return this;
         }
 
+        /**
+         * Sets the function to use for creating the cache key, if caching is enabled.
+         *
+         * @param cacheKeyFunction the cache key function to use
+         * @return this builder for fluent coding
+         */
         public Builder setCacheKeyFunction(CacheKey<?> cacheKeyFunction) {
             this.cacheKeyFunction = cacheKeyFunction;
             return this;
         }
 
+        /**
+         * Sets the cache map implementation to use for caching, if caching is enabled.
+         *
+         * @param cacheMap the cache map instance
+         * @return this builder for fluent coding
+         */
         public Builder setCacheMap(CacheMap<?, ?> cacheMap) {
             this.cacheMap = cacheMap;
             return this;
         }
 
+        /**
+         * Sets the value cache implementation to use for caching values, if caching is enabled.
+         *
+         * @param valueCache the value cache instance
+         * @return this builder for fluent coding
+         */
         public Builder setValueCache(ValueCache<?, ?> valueCache) {
             this.valueCache = valueCache;
             return this;
         }
 
+        /**
+         * Sets the maximum number of keys that will be presented to the {@link BatchLoader} function
+         * before they are split into multiple class
+         *
+         * @param maxBatchSize the maximum batch size
+         * @return this builder for fluent coding
+         */
         public Builder setMaxBatchSize(int maxBatchSize) {
             this.maxBatchSize = maxBatchSize;
             return this;
         }
 
+        /**
+         * Sets the statistics collector supplier that will be used with these data loader options.  Since it uses
+         * the supplier pattern, you can create a new statistics collector on each call, or you can reuse
+         * a common value
+         *
+         * @param statisticsCollector the statistics collector to use
+         * @return this builder for fluent coding
+         */
         public Builder setStatisticsCollector(Supplier<StatisticsCollector> statisticsCollector) {
             this.statisticsCollector = statisticsCollector;
             return this;
         }
 
+        /**
+         * Sets the batch loader environment provider that will be used to give context to batch load functions
+         *
+         * @param environmentProvider the batch loader context provider
+         * @return this builder for fluent coding
+         */
         public Builder setBatchLoaderContextProvider(BatchLoaderContextProvider environmentProvider) {
             this.environmentProvider = environmentProvider;
             return this;
         }
 
+        /**
+         * Sets the {@link ValueCacheOptions} that control how the {@link ValueCache} will be used
+         *
+         * @param valueCacheOptions the value cache options
+         * @return this builder for fluent coding
+         */
         public Builder setValueCacheOptions(ValueCacheOptions valueCacheOptions) {
             this.valueCacheOptions = valueCacheOptions;
             return this;
         }
 
+        /**
+         * Sets in a new {@link BatchLoaderScheduler} that allows the call to a {@link BatchLoader} function to be scheduled
+         * to some future time.
+         *
+         * @param batchLoaderScheduler the scheduler
+         * @return this builder for fluent coding
+         */
         public Builder setBatchLoaderScheduler(BatchLoaderScheduler batchLoaderScheduler) {
             this.batchLoaderScheduler = batchLoaderScheduler;
             return this;
         }
 
+        /**
+         * Sets in a new {@link DataLoaderInstrumentation}
+         *
+         * @param instrumentation the new {@link DataLoaderInstrumentation}
+         * @return this builder for fluent coding
+         */
         public Builder setInstrumentation(DataLoaderInstrumentation instrumentation) {
             this.instrumentation = nonNull(instrumentation);
             return this;

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -105,7 +105,7 @@ public class ReadmeExamples {
 
     private void callContextExample() {
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -120,7 +120,7 @@ public class ReadmeExamples {
 
     private void keyContextExample() {
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -236,7 +236,7 @@ public class ReadmeExamples {
     BatchLoader<String, User> teamsBatchLoader;
 
     private void disableCache() {
-        DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().setCachingEnabled(false));
+        DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().withCachingEnabled(false));
 
 
         userDataLoader.load("A");
@@ -283,7 +283,7 @@ public class ReadmeExamples {
     private void customCache() {
 
         MyCustomCache customCache = new MyCustomCache();
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setCacheMap(customCache);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withCacheMap(customCache);
         DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 
@@ -311,7 +311,7 @@ public class ReadmeExamples {
 
     private void statsConfigExample() {
 
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 
@@ -410,7 +410,7 @@ public class ReadmeExamples {
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setInstrumentation(timingInstrumentation);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withInstrumentation(timingInstrumentation);
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 

--- a/src/test/java/ReadmeExamples.java
+++ b/src/test/java/ReadmeExamples.java
@@ -105,7 +105,7 @@ public class ReadmeExamples {
 
     private void callContextExample() {
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx()).build();
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -120,7 +120,7 @@ public class ReadmeExamples {
 
     private void keyContextExample() {
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx());
+                .setBatchLoaderContextProvider(() -> SecurityCtx.getCallingUserCtx()).build();
 
         BatchLoaderWithContext<String, String> batchLoader = new BatchLoaderWithContext<String, String>() {
             @Override
@@ -236,7 +236,7 @@ public class ReadmeExamples {
     BatchLoader<String, User> teamsBatchLoader;
 
     private void disableCache() {
-        DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().withCachingEnabled(false));
+        DataLoaderFactory.newDataLoader(userBatchLoader, DataLoaderOptions.newOptions().setCachingEnabled(false).build());
 
 
         userDataLoader.load("A");
@@ -283,7 +283,7 @@ public class ReadmeExamples {
     private void customCache() {
 
         MyCustomCache customCache = new MyCustomCache();
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withCacheMap(customCache);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setCacheMap(customCache).build();
         DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 
@@ -311,7 +311,7 @@ public class ReadmeExamples {
 
     private void statsConfigExample() {
 
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withStatisticsCollector(() -> new ThreadLocalStatisticsCollector());
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setStatisticsCollector(() -> new ThreadLocalStatisticsCollector()).build();
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 
@@ -410,7 +410,7 @@ public class ReadmeExamples {
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withInstrumentation(timingInstrumentation);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setInstrumentation(timingInstrumentation).build();
         DataLoader<String, User> userDataLoader = DataLoaderFactory.newDataLoader(userBatchLoader, options);
     }
 

--- a/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
@@ -41,7 +41,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
             return CompletableFuture.completedFuture(list);
         };
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> "ctx");
+                .withBatchLoaderContextProvider(() -> "ctx");
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A");
@@ -61,7 +61,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void key_contexts_are_passed_to_batch_loader_function() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> "ctx");
+                .withBatchLoaderContextProvider(() -> "ctx");
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");
@@ -81,8 +81,8 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void key_contexts_are_passed_to_batch_loader_function_when_batching_disabled() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchingEnabled(false)
-                .setBatchLoaderContextProvider(() -> "ctx");
+                .withBatchingEnabled(false)
+                .withBatchLoaderContextProvider(() -> "ctx");
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         CompletableFuture<String> aLoad = loader.load("A", "aCtx");
@@ -104,7 +104,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void missing_key_contexts_are_passed_to_batch_loader_function() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> "ctx");
+                .withBatchLoaderContextProvider(() -> "ctx");
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");
@@ -133,7 +133,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
             return CompletableFuture.completedFuture(map);
         };
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> "ctx");
+                .withBatchLoaderContextProvider(() -> "ctx");
         DataLoader<String, String> loader = newMappedDataLoader(mapBatchLoader, options);
 
         loader.load("A", "aCtx");
@@ -199,8 +199,8 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void mmap_semantics_apply_to_batch_loader_context() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .setBatchLoaderContextProvider(() -> "ctx")
-                .setCachingEnabled(false);
+                .withBatchLoaderContextProvider(() -> "ctx")
+                .withCachingEnabled(false);
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");

--- a/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBatchLoaderEnvironmentTest.java
@@ -41,7 +41,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
             return CompletableFuture.completedFuture(list);
         };
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> "ctx");
+                .setBatchLoaderContextProvider(() -> "ctx").build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A");
@@ -61,7 +61,7 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void key_contexts_are_passed_to_batch_loader_function() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> "ctx");
+                .setBatchLoaderContextProvider(() -> "ctx").build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");
@@ -81,8 +81,9 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void key_contexts_are_passed_to_batch_loader_function_when_batching_disabled() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchingEnabled(false)
-                .withBatchLoaderContextProvider(() -> "ctx");
+                .setBatchingEnabled(false)
+                .setBatchLoaderContextProvider(() -> "ctx")
+                .build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         CompletableFuture<String> aLoad = loader.load("A", "aCtx");
@@ -104,7 +105,8 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void missing_key_contexts_are_passed_to_batch_loader_function() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> "ctx");
+                .setBatchLoaderContextProvider(() -> "ctx")
+                .build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");
@@ -133,7 +135,8 @@ public class DataLoaderBatchLoaderEnvironmentTest {
             return CompletableFuture.completedFuture(map);
         };
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> "ctx");
+                .setBatchLoaderContextProvider(() -> "ctx")
+                .build();
         DataLoader<String, String> loader = newMappedDataLoader(mapBatchLoader, options);
 
         loader.load("A", "aCtx");
@@ -199,8 +202,9 @@ public class DataLoaderBatchLoaderEnvironmentTest {
     public void mmap_semantics_apply_to_batch_loader_context() {
         BatchLoaderWithContext<String, String> batchLoader = contextBatchLoader();
         DataLoaderOptions options = DataLoaderOptions.newOptions()
-                .withBatchLoaderContextProvider(() -> "ctx")
-                .withCachingEnabled(false);
+                .setBatchLoaderContextProvider(() -> "ctx")
+                .setCachingEnabled(false)
+                .build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, options);
 
         loader.load("A", "aCtx");

--- a/src/test/java/org/dataloader/DataLoaderBuilderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBuilderTest.java
@@ -13,7 +13,7 @@ public class DataLoaderBuilderTest {
     BatchLoader<String, Object> batchLoader2 = keys -> null;
 
     DataLoaderOptions defaultOptions = DataLoaderOptions.newOptions();
-    DataLoaderOptions differentOptions = DataLoaderOptions.newOptions().setCachingEnabled(false);
+    DataLoaderOptions differentOptions = DataLoaderOptions.newOptions().withCachingEnabled(false);
 
     @Test
     void canBuildNewDataLoaders() {

--- a/src/test/java/org/dataloader/DataLoaderBuilderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderBuilderTest.java
@@ -12,8 +12,8 @@ public class DataLoaderBuilderTest {
 
     BatchLoader<String, Object> batchLoader2 = keys -> null;
 
-    DataLoaderOptions defaultOptions = DataLoaderOptions.newOptions();
-    DataLoaderOptions differentOptions = DataLoaderOptions.newOptions().withCachingEnabled(false);
+    DataLoaderOptions defaultOptions = DataLoaderOptions.newOptions().build();
+    DataLoaderOptions differentOptions = DataLoaderOptions.newOptions().setCachingEnabled(false).build();
 
     @Test
     void canBuildNewDataLoaders() {

--- a/src/test/java/org/dataloader/DataLoaderFactoryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderFactoryTest.java
@@ -14,7 +14,7 @@ class DataLoaderFactoryTest {
     @Test
     void can_create_via_builder() {
         BatchLoaderWithContext<String, String> loader = (keys, environment) -> CompletableFuture.completedFuture(keys);
-        DataLoaderOptions options = DataLoaderOptions.newOptionsBuilder().setBatchingEnabled(true).build();
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchingEnabled(true).build();
 
         DataLoader<String, String> dl = DataLoaderFactory.<String, String>builder()
                 .name("x").batchLoader(loader).options(options).build();

--- a/src/test/java/org/dataloader/DataLoaderOptionsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderOptionsTest.java
@@ -89,25 +89,25 @@ class DataLoaderOptionsTest {
 
     @Test
     void canBuildOk() {
-        assertThat(optionsDefault.setBatchingEnabled(false).batchingEnabled(),
+        assertThat(optionsDefault.withBatchingEnabled(false).batchingEnabled(),
                 equalTo(false));
-        assertThat(optionsDefault.setBatchLoaderScheduler(testBatchLoaderScheduler).getBatchLoaderScheduler(),
+        assertThat(optionsDefault.withBatchLoaderScheduler(testBatchLoaderScheduler).getBatchLoaderScheduler(),
                 equalTo(testBatchLoaderScheduler));
-        assertThat(optionsDefault.setBatchLoaderContextProvider(testBatchLoaderContextProvider).getBatchLoaderContextProvider(),
+        assertThat(optionsDefault.withBatchLoaderContextProvider(testBatchLoaderContextProvider).getBatchLoaderContextProvider(),
                 equalTo(testBatchLoaderContextProvider));
-        assertThat(optionsDefault.setCacheMap(testCacheMap).cacheMap().get(),
+        assertThat(optionsDefault.withCacheMap(testCacheMap).cacheMap().get(),
                 equalTo(testCacheMap));
-        assertThat(optionsDefault.setCachingEnabled(false).cachingEnabled(),
+        assertThat(optionsDefault.withCachingEnabled(false).cachingEnabled(),
                 equalTo(false));
-        assertThat(optionsDefault.setValueCacheOptions(testValueCacheOptions).getValueCacheOptions(),
+        assertThat(optionsDefault.withValueCacheOptions(testValueCacheOptions).getValueCacheOptions(),
                 equalTo(testValueCacheOptions));
-        assertThat(optionsDefault.setCacheKeyFunction(testCacheKey).cacheKeyFunction().get(),
+        assertThat(optionsDefault.withCacheKeyFunction(testCacheKey).cacheKeyFunction().get(),
                 equalTo(testCacheKey));
-        assertThat(optionsDefault.setValueCache(testValueCache).valueCache().get(),
+        assertThat(optionsDefault.withValueCache(testValueCache).valueCache().get(),
                 equalTo(testValueCache));
-        assertThat(optionsDefault.setMaxBatchSize(10).maxBatchSize(),
+        assertThat(optionsDefault.withMaxBatchSize(10).maxBatchSize(),
                 equalTo(10));
-        assertThat(optionsDefault.setStatisticsCollector(testStatisticsCollectorSupplier).getStatisticsCollector(),
+        assertThat(optionsDefault.withStatisticsCollector(testStatisticsCollectorSupplier).getStatisticsCollector(),
                 equalTo(testStatisticsCollectorSupplier.get()));
 
         DataLoaderOptions builtOptions = optionsDefault.transform(builder -> {

--- a/src/test/java/org/dataloader/DataLoaderOptionsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderOptionsTest.java
@@ -31,7 +31,7 @@ class DataLoaderOptionsTest {
         assertThat(optionsDefault.maxBatchSize(), equalTo(-1));
         assertThat(optionsDefault.getBatchLoaderScheduler(), equalTo(null));
 
-        DataLoaderOptions builtOptions = DataLoaderOptions.newOptionsBuilder().build();
+        DataLoaderOptions builtOptions = DataLoaderOptions.newDefaultOptions();
         assertThat(builtOptions, equalTo(optionsDefault));
         assertThat(builtOptions == optionsDefault, equalTo(false));
 
@@ -43,11 +43,7 @@ class DataLoaderOptionsTest {
 
     @Test
     void canCopyOk() {
-        DataLoaderOptions optionsNext = new DataLoaderOptions(optionsDefault);
-        assertThat(optionsNext, equalTo(optionsDefault));
-        assertThat(optionsNext == optionsDefault, equalTo(false));
-
-        optionsNext = DataLoaderOptions.newDataLoaderOptions(optionsDefault).build();
+        DataLoaderOptions optionsNext = DataLoaderOptions.newOptions(optionsDefault).build();
         assertThat(optionsNext, equalTo(optionsDefault));
         assertThat(optionsNext == optionsDefault, equalTo(false));
     }
@@ -89,25 +85,25 @@ class DataLoaderOptionsTest {
 
     @Test
     void canBuildOk() {
-        assertThat(optionsDefault.withBatchingEnabled(false).batchingEnabled(),
+        assertThat(optionsDefault.transform(b -> b.setBatchingEnabled(false)).batchingEnabled(),
                 equalTo(false));
-        assertThat(optionsDefault.withBatchLoaderScheduler(testBatchLoaderScheduler).getBatchLoaderScheduler(),
+        assertThat(optionsDefault.transform(b -> b.setBatchLoaderScheduler(testBatchLoaderScheduler)).getBatchLoaderScheduler(),
                 equalTo(testBatchLoaderScheduler));
-        assertThat(optionsDefault.withBatchLoaderContextProvider(testBatchLoaderContextProvider).getBatchLoaderContextProvider(),
+        assertThat(optionsDefault.transform(b -> b.setBatchLoaderContextProvider(testBatchLoaderContextProvider)).getBatchLoaderContextProvider(),
                 equalTo(testBatchLoaderContextProvider));
-        assertThat(optionsDefault.withCacheMap(testCacheMap).cacheMap().get(),
+        assertThat(optionsDefault.transform(b -> b.setCacheMap(testCacheMap)).cacheMap().get(),
                 equalTo(testCacheMap));
-        assertThat(optionsDefault.withCachingEnabled(false).cachingEnabled(),
+        assertThat(optionsDefault.transform(b -> b.setCachingEnabled(false)).cachingEnabled(),
                 equalTo(false));
-        assertThat(optionsDefault.withValueCacheOptions(testValueCacheOptions).getValueCacheOptions(),
+        assertThat(optionsDefault.transform(b -> b.setValueCacheOptions(testValueCacheOptions)).getValueCacheOptions(),
                 equalTo(testValueCacheOptions));
-        assertThat(optionsDefault.withCacheKeyFunction(testCacheKey).cacheKeyFunction().get(),
+        assertThat(optionsDefault.transform(b -> b.setCacheKeyFunction(testCacheKey)).cacheKeyFunction().get(),
                 equalTo(testCacheKey));
-        assertThat(optionsDefault.withValueCache(testValueCache).valueCache().get(),
+        assertThat(optionsDefault.transform(b -> b.setValueCache(testValueCache)).valueCache().get(),
                 equalTo(testValueCache));
-        assertThat(optionsDefault.withMaxBatchSize(10).maxBatchSize(),
+        assertThat(optionsDefault.transform(b -> b.setMaxBatchSize(10)).maxBatchSize(),
                 equalTo(10));
-        assertThat(optionsDefault.withStatisticsCollector(testStatisticsCollectorSupplier).getStatisticsCollector(),
+        assertThat(optionsDefault.transform(b -> b.setStatisticsCollector(testStatisticsCollectorSupplier)).getStatisticsCollector(),
                 equalTo(testStatisticsCollectorSupplier.get()));
 
         DataLoaderOptions builtOptions = optionsDefault.transform(builder -> {
@@ -150,7 +146,7 @@ class DataLoaderOptionsTest {
     @Test
     void canBuildViaBuilderOk() {
 
-        DataLoaderOptions.Builder builder = DataLoaderOptions.newOptionsBuilder();
+        DataLoaderOptions.Builder builder = DataLoaderOptions.newOptions();
         builder.setBatchingEnabled(false);
         builder.setCachingExceptionsEnabled(false);
         builder.setCachingEnabled(false);
@@ -196,7 +192,7 @@ class DataLoaderOptionsTest {
         };
         BatchLoaderContextProvider contextProvider1 = () -> null;
 
-        DataLoaderOptions startingOptions = DataLoaderOptions.newOptionsBuilder().setBatchingEnabled(false)
+        DataLoaderOptions startingOptions = DataLoaderOptions.newOptions().setBatchingEnabled(false)
                 .setCachingEnabled(false)
                 .setInstrumentation(instrumentation1)
                 .setBatchLoaderContextProvider(contextProvider1)

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -79,13 +79,13 @@ public class DataLoaderRegistryTest {
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
         DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new).build()
         );
         DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new).build()
         );
         DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new).build()
         );
 
         registry.register("a", dlA).register("b", dlB).register("c", dlC);

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -79,13 +79,13 @@ public class DataLoaderRegistryTest {
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
         DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
         );
         DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
         );
         DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader,
-                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
         );
 
         registry.register("a", dlA).register("b", dlB).register("c", dlC);

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -33,7 +33,7 @@ public class DataLoaderStatsTest {
     public void stats_are_collected_by_default() {
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
         DataLoader<String, String> loader = newDataLoader(batchLoader,
-                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new).build()
         );
 
         loader.load("A");
@@ -75,7 +75,7 @@ public class DataLoaderStatsTest {
         collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
 
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
-        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().withStatisticsCollector(() -> collector);
+        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().setStatisticsCollector(() -> collector).build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, loaderOptions);
 
         loader.load("A");
@@ -113,7 +113,7 @@ public class DataLoaderStatsTest {
         StatisticsCollector collector = new SimpleStatisticsCollector();
 
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
-        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().withStatisticsCollector(() -> collector).withCachingEnabled(false);
+        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().setStatisticsCollector(() -> collector).setCachingEnabled(false).build();
         DataLoader<String, String> loader = newDataLoader(batchLoader, loaderOptions);
 
         loader.load("A");
@@ -166,7 +166,7 @@ public class DataLoaderStatsTest {
     @Test
     public void stats_are_collected_on_exceptions() {
         DataLoader<String, String> loader = DataLoaderFactory.newDataLoaderWithTry(batchLoaderThatBlows,
-                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new).build()
         );
 
         loader.load("A");
@@ -290,7 +290,7 @@ public class DataLoaderStatsTest {
     public void context_is_passed_through_to_collector() {
         ContextPassingStatisticsCollector statisticsCollector = new ContextPassingStatisticsCollector();
         DataLoader<String, Try<String>> loader = newDataLoader(batchLoaderThatBlows,
-                DataLoaderOptions.newOptions().withStatisticsCollector(() -> statisticsCollector)
+                DataLoaderOptions.newOptions().setStatisticsCollector(() -> statisticsCollector).build()
         );
 
         loader.load("key", "keyContext");

--- a/src/test/java/org/dataloader/DataLoaderStatsTest.java
+++ b/src/test/java/org/dataloader/DataLoaderStatsTest.java
@@ -33,7 +33,7 @@ public class DataLoaderStatsTest {
     public void stats_are_collected_by_default() {
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
         DataLoader<String, String> loader = newDataLoader(batchLoader,
-                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
         );
 
         loader.load("A");
@@ -75,7 +75,7 @@ public class DataLoaderStatsTest {
         collector.incrementBatchLoadCountBy(1, new IncrementBatchLoadCountByStatisticsContext<>(1, null));
 
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
-        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().setStatisticsCollector(() -> collector);
+        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().withStatisticsCollector(() -> collector);
         DataLoader<String, String> loader = newDataLoader(batchLoader, loaderOptions);
 
         loader.load("A");
@@ -113,7 +113,7 @@ public class DataLoaderStatsTest {
         StatisticsCollector collector = new SimpleStatisticsCollector();
 
         BatchLoader<String, String> batchLoader = CompletableFuture::completedFuture;
-        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().setStatisticsCollector(() -> collector).setCachingEnabled(false);
+        DataLoaderOptions loaderOptions = DataLoaderOptions.newOptions().withStatisticsCollector(() -> collector).withCachingEnabled(false);
         DataLoader<String, String> loader = newDataLoader(batchLoader, loaderOptions);
 
         loader.load("A");
@@ -166,7 +166,7 @@ public class DataLoaderStatsTest {
     @Test
     public void stats_are_collected_on_exceptions() {
         DataLoader<String, String> loader = DataLoaderFactory.newDataLoaderWithTry(batchLoaderThatBlows,
-                DataLoaderOptions.newOptions().setStatisticsCollector(SimpleStatisticsCollector::new)
+                DataLoaderOptions.newOptions().withStatisticsCollector(SimpleStatisticsCollector::new)
         );
 
         loader.load("A");
@@ -290,7 +290,7 @@ public class DataLoaderStatsTest {
     public void context_is_passed_through_to_collector() {
         ContextPassingStatisticsCollector statisticsCollector = new ContextPassingStatisticsCollector();
         DataLoader<String, Try<String>> loader = newDataLoader(batchLoaderThatBlows,
-                DataLoaderOptions.newOptions().setStatisticsCollector(() -> statisticsCollector)
+                DataLoaderOptions.newOptions().withStatisticsCollector(() -> statisticsCollector)
         );
 
         loader.load("key", "keyContext");

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -47,6 +47,7 @@ import static java.util.Collections.*;
 import static java.util.concurrent.CompletableFuture.*;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
+import static org.dataloader.DataLoaderOptions.newDefaultOptions;
 import static org.dataloader.DataLoaderOptions.newOptions;
 import static org.dataloader.fixtures.TestKit.areAllDone;
 import static org.dataloader.fixtures.TestKit.listFrom;
@@ -588,7 +589,7 @@ public class DataLoaderTest {
     @ParameterizedTest
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_NOT_Cache_failed_fetches_if_told_not_too(TestDataLoaderFactory factory) {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withCachingExceptionsEnabled(false);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setCachingExceptionsEnabled(false).build();
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Object> errorLoader = factory.idLoaderAllExceptions(options, loadCalls);
 
@@ -736,7 +737,7 @@ public class DataLoaderTest {
     public void should_Disable_caching(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().withCachingEnabled(false), loadCalls);
+                factory.idLoader(newOptions().setCachingEnabled(false).build(), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -774,7 +775,7 @@ public class DataLoaderTest {
     public void should_work_with_duplicate_keys_when_caching_disabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().withCachingEnabled(false), loadCalls);
+                factory.idLoader(newOptions().setCachingEnabled(false).build(), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -797,7 +798,7 @@ public class DataLoaderTest {
     public void should_work_with_duplicate_keys_when_caching_enabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().withCachingEnabled(true), loadCalls);
+                factory.idLoader(newOptions().setCachingEnabled(true).build(), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -817,7 +818,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_a_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn()).build();
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -839,7 +840,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_objects_with_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn()).build();
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -864,7 +865,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_different_order_of_keys(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn()).build();
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("a", 123).put("b", 321);
@@ -887,7 +888,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_priming_the_cache_with_an_object_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn()).build();
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -910,7 +911,7 @@ public class DataLoaderTest {
     public void should_Accept_a_custom_cache_map_implementation(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         CustomCacheMap customMap = new CustomCacheMap();
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withCacheMap(customMap);
+        DataLoaderOptions options = newOptions().setCacheMap(customMap).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -961,7 +962,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_degrade_gracefully_if_cache_get_throws(TestDataLoaderFactory factory) {
         CacheMap<String, Object> cache = new ThrowingCacheMap();
-        DataLoaderOptions options = newOptions().withCachingEnabled(true).withCacheMap(cache);
+        DataLoaderOptions options = newOptions().setCachingEnabled(true).setCacheMap(cache).build();
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
@@ -976,7 +977,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_should_dispatch_immediately(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withBatchingEnabled(false);
+        DataLoaderOptions options = newOptions().setBatchingEnabled(false).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fa = identityLoader.load("A");
@@ -1005,7 +1006,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_and_caching_disabled_should_dispatch_immediately_and_forget(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withBatchingEnabled(false).withCachingEnabled(false);
+        DataLoaderOptions options = newOptions().setBatchingEnabled(false).setCachingEnabled(false).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fa = identityLoader.load("A");
@@ -1037,7 +1038,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batches_multiple_requests_with_max_batch_size(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
-        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().withMaxBatchSize(2), loadCalls);
+        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(2).build(), loadCalls);
 
         CompletableFuture<Integer> f1 = identityLoader.load(1);
         CompletableFuture<Integer> f2 = identityLoader.load(2);
@@ -1059,7 +1060,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void can_split_max_batch_sizes_correctly(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
-        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().withMaxBatchSize(5), loadCalls);
+        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(5).build(), loadCalls);
 
         for (int i = 0; i < 21; i++) {
             identityLoader.load(i);
@@ -1082,7 +1083,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Batch_loads_occurring_within_futures(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoader<String, String> identityLoader = factory.idLoader(newOptions(), loadCalls);
+        DataLoader<String, String> identityLoader = factory.idLoader(newDefaultOptions(), loadCalls);
 
         Supplier<Object> nullValue = () -> null;
 

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -588,7 +588,7 @@ public class DataLoaderTest {
     @ParameterizedTest
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_NOT_Cache_failed_fetches_if_told_not_too(TestDataLoaderFactory factory) {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setCachingExceptionsEnabled(false);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withCachingExceptionsEnabled(false);
         List<Collection<Integer>> loadCalls = new ArrayList<>();
         DataLoader<Integer, Object> errorLoader = factory.idLoaderAllExceptions(options, loadCalls);
 
@@ -736,7 +736,7 @@ public class DataLoaderTest {
     public void should_Disable_caching(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().setCachingEnabled(false), loadCalls);
+                factory.idLoader(newOptions().withCachingEnabled(false), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -774,7 +774,7 @@ public class DataLoaderTest {
     public void should_work_with_duplicate_keys_when_caching_disabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().setCachingEnabled(false), loadCalls);
+                factory.idLoader(newOptions().withCachingEnabled(false), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -797,7 +797,7 @@ public class DataLoaderTest {
     public void should_work_with_duplicate_keys_when_caching_enabled(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader =
-                factory.idLoader(newOptions().setCachingEnabled(true), loadCalls);
+                factory.idLoader(newOptions().withCachingEnabled(true), loadCalls);
 
         CompletableFuture<String> future1 = identityLoader.load("A");
         CompletableFuture<String> future2 = identityLoader.load("B");
@@ -817,7 +817,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_a_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -839,7 +839,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Clear_objects_with_complex_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -864,7 +864,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Accept_objects_with_different_order_of_keys(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("a", 123).put("b", 321);
@@ -887,7 +887,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_Allow_priming_the_cache_with_an_object_key(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         List<Collection<JsonObject>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setCacheKeyFunction(getJsonObjectCacheMapFn());
+        DataLoaderOptions options = newOptions().withCacheKeyFunction(getJsonObjectCacheMapFn());
         DataLoader<JsonObject, JsonObject> identityLoader = factory.idLoader(options, loadCalls);
 
         JsonObject key1 = new JsonObject().put("id", 123);
@@ -910,7 +910,7 @@ public class DataLoaderTest {
     public void should_Accept_a_custom_cache_map_implementation(TestDataLoaderFactory factory) throws ExecutionException, InterruptedException {
         CustomCacheMap customMap = new CustomCacheMap();
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setCacheMap(customMap);
+        DataLoaderOptions options = newOptions().withCacheMap(customMap);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -961,7 +961,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void should_degrade_gracefully_if_cache_get_throws(TestDataLoaderFactory factory) {
         CacheMap<String, Object> cache = new ThrowingCacheMap();
-        DataLoaderOptions options = newOptions().setCachingEnabled(true).setCacheMap(cache);
+        DataLoaderOptions options = newOptions().withCachingEnabled(true).withCacheMap(cache);
         List<Collection<String>> loadCalls = new ArrayList<>();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
@@ -976,7 +976,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_should_dispatch_immediately(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setBatchingEnabled(false);
+        DataLoaderOptions options = newOptions().withBatchingEnabled(false);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fa = identityLoader.load("A");
@@ -1005,7 +1005,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batching_disabled_and_caching_disabled_should_dispatch_immediately_and_forget(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setBatchingEnabled(false).setCachingEnabled(false);
+        DataLoaderOptions options = newOptions().withBatchingEnabled(false).withCachingEnabled(false);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fa = identityLoader.load("A");
@@ -1037,7 +1037,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void batches_multiple_requests_with_max_batch_size(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
-        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(2), loadCalls);
+        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().withMaxBatchSize(2), loadCalls);
 
         CompletableFuture<Integer> f1 = identityLoader.load(1);
         CompletableFuture<Integer> f2 = identityLoader.load(2);
@@ -1059,7 +1059,7 @@ public class DataLoaderTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void can_split_max_batch_sizes_correctly(TestDataLoaderFactory factory) {
         List<Collection<Integer>> loadCalls = new ArrayList<>();
-        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().setMaxBatchSize(5), loadCalls);
+        DataLoader<Integer, Integer> identityLoader = factory.idLoader(newOptions().withMaxBatchSize(5), loadCalls);
 
         for (int i = 0; i < 21; i++) {
             identityLoader.load(i);

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -101,7 +101,7 @@ public class DataLoaderTest {
     @Test
     public void should_Build_a_named_data_loader() {
         BatchLoader<Integer, Integer> loadFunction = CompletableFuture::completedFuture;
-        DataLoader<Integer, Integer> dl = newDataLoader("name", loadFunction, DataLoaderOptions.newOptions());
+        DataLoader<Integer, Integer> dl = newDataLoader("name", loadFunction, DataLoaderOptions.newDefaultOptions());
 
         assertNotNull(dl.getName());
         assertThat(dl.getName(), equalTo("name"));

--- a/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
+++ b/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
@@ -36,7 +36,7 @@ public class DataLoaderValueCacheTest {
     @MethodSource("org.dataloader.fixtures.parameterized.TestDataLoaderFactories#get")
     public void test_by_default_we_have_no_value_caching(TestDataLoaderFactory factory) {
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions();
+        DataLoaderOptions options = newOptions().build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -72,7 +72,7 @@ public class DataLoaderValueCacheTest {
     public void should_accept_a_remote_value_store_for_caching(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache();
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -127,7 +127,7 @@ public class DataLoaderValueCacheTest {
         ValueCache<String, Object> caffeineValueCache = new CaffeineValueCache(caffeineCache);
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(caffeineValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(caffeineValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -170,7 +170,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.set("b", "From Cache");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -198,7 +198,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -237,7 +237,7 @@ public class DataLoaderValueCacheTest {
 
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -279,7 +279,7 @@ public class DataLoaderValueCacheTest {
 
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -323,7 +323,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -359,7 +359,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(false);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(false).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -403,7 +403,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.asMap().put("c", "cachedC");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(true);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(true).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -444,7 +444,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.asMap().put("a", "cachedA");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(true).withBatchingEnabled(false);
+        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(true).setBatchingEnabled(false).build();
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");

--- a/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
+++ b/src/test/java/org/dataloader/DataLoaderValueCacheTest.java
@@ -72,7 +72,7 @@ public class DataLoaderValueCacheTest {
     public void should_accept_a_remote_value_store_for_caching(TestDataLoaderFactory factory) {
         CustomValueCache customValueCache = new CustomValueCache();
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -127,7 +127,7 @@ public class DataLoaderValueCacheTest {
         ValueCache<String, Object> caffeineValueCache = new CaffeineValueCache(caffeineCache);
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(caffeineValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(caffeineValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         // Fetches as expected
@@ -170,7 +170,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.set("b", "From Cache");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -198,7 +198,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -237,7 +237,7 @@ public class DataLoaderValueCacheTest {
 
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -279,7 +279,7 @@ public class DataLoaderValueCacheTest {
 
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -323,7 +323,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -359,7 +359,7 @@ public class DataLoaderValueCacheTest {
         };
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(false);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(false);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -403,7 +403,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.asMap().put("c", "cachedC");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(true);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(true);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");
@@ -444,7 +444,7 @@ public class DataLoaderValueCacheTest {
         customValueCache.asMap().put("a", "cachedA");
 
         List<Collection<String>> loadCalls = new ArrayList<>();
-        DataLoaderOptions options = newOptions().setValueCache(customValueCache).setCachingEnabled(true).setBatchingEnabled(false);
+        DataLoaderOptions options = newOptions().withValueCache(customValueCache).withCachingEnabled(true).withBatchingEnabled(false);
         DataLoader<String, String> identityLoader = factory.idLoader(options, loadCalls);
 
         CompletableFuture<String> fA = identityLoader.load("a");

--- a/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
+++ b/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
@@ -66,7 +66,7 @@ public class DelegatingDataLoaderTest {
 
     @Test
     void can_delegate_simple_properties() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions();
+        DataLoaderOptions options = DataLoaderOptions.newOptions().build();
         BatchLoader<String, String> loadFunction = CompletableFuture::completedFuture;
 
         DataLoader<String, String> rawLoader = DataLoaderFactory.newDataLoader("name", loadFunction, options);

--- a/src/test/java/org/dataloader/instrumentation/ChainedDataLoaderInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/ChainedDataLoaderInstrumentationTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.awaitility.Awaitility.await;
-import static org.dataloader.DataLoaderOptions.newOptionsBuilder;
+import static org.dataloader.DataLoaderOptions.newOptions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -37,7 +37,7 @@ public class ChainedDataLoaderInstrumentationTest {
         // just to prove its useless but harmless
         ChainedDataLoaderInstrumentation chainedItn = new ChainedDataLoaderInstrumentation();
 
-        DataLoaderOptions options = newOptionsBuilder().setInstrumentation(chainedItn).build();
+        DataLoaderOptions options = newOptions().setInstrumentation(chainedItn).build();
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(TestKit.keysAsValues(), options);
 
@@ -57,7 +57,7 @@ public class ChainedDataLoaderInstrumentationTest {
         ChainedDataLoaderInstrumentation chainedItn = new ChainedDataLoaderInstrumentation()
                 .add(capturingA);
 
-        DataLoaderOptions options = newOptionsBuilder().setInstrumentation(chainedItn).build();
+        DataLoaderOptions options = newOptions().setInstrumentation(chainedItn).build();
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(TestKit.keysAsValues(), options);
 
@@ -88,7 +88,7 @@ public class ChainedDataLoaderInstrumentationTest {
                 .add(capturingB)
                 .add(capturingButReturnsNull);
 
-        DataLoaderOptions options = newOptionsBuilder().setInstrumentation(chainedItn).build();
+        DataLoaderOptions options = newOptions().setInstrumentation(chainedItn).build();
 
         DataLoader<String, String> dl = factory.idLoader(options);
 

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderInstrumentationTest.java
@@ -48,9 +48,10 @@ public class DataLoaderInstrumentationTest {
             }
         };
 
-        DataLoaderOptions options = new DataLoaderOptions()
-                .withInstrumentation(instrumentation)
-                .withMaxBatchSize(5);
+        DataLoaderOptions options = DataLoaderOptions.newOptions()
+                .setInstrumentation(instrumentation)
+                .setMaxBatchSize(5)
+                .build();
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
@@ -109,9 +110,10 @@ public class DataLoaderInstrumentationTest {
             }
         };
 
-        DataLoaderOptions options = new DataLoaderOptions()
-                .withInstrumentation(instrumentation)
-                .withMaxBatchSize(5);
+        DataLoaderOptions options = DataLoaderOptions.newOptions()
+                .setInstrumentation(instrumentation)
+                .setMaxBatchSize(5)
+                .build();
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
@@ -155,7 +157,7 @@ public class DataLoaderInstrumentationTest {
             }
         };
 
-        DataLoaderOptions options = new DataLoaderOptions().withInstrumentation(instrumentation);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setInstrumentation(instrumentation).build();
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
         dl.load("A", "kcA");

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderInstrumentationTest.java
@@ -49,8 +49,8 @@ public class DataLoaderInstrumentationTest {
         };
 
         DataLoaderOptions options = new DataLoaderOptions()
-                .setInstrumentation(instrumentation)
-                .setMaxBatchSize(5);
+                .withInstrumentation(instrumentation)
+                .withMaxBatchSize(5);
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
@@ -110,8 +110,8 @@ public class DataLoaderInstrumentationTest {
         };
 
         DataLoaderOptions options = new DataLoaderOptions()
-                .setInstrumentation(instrumentation)
-                .setMaxBatchSize(5);
+                .withInstrumentation(instrumentation)
+                .withMaxBatchSize(5);
 
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
@@ -155,7 +155,7 @@ public class DataLoaderInstrumentationTest {
             }
         };
 
-        DataLoaderOptions options = new DataLoaderOptions().setInstrumentation(instrumentation);
+        DataLoaderOptions options = new DataLoaderOptions().withInstrumentation(instrumentation);
         DataLoader<String, String> dl = DataLoaderFactory.newDataLoader(snoozingBatchLoader, options);
 
         dl.load("A", "kcA");

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
@@ -120,9 +120,9 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void wontDoAnyThingIfThereTheyAreTheSameInstrumentationAlready() {
-        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newY = dlY.transform(builder ->  builder.options(dlY.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newZ = dlZ.transform(builder ->  builder.options(dlZ.getOptions().setInstrumentation(instrA)));
+        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().transform(b-> b.setInstrumentation(instrA))));
+        DataLoader<String, String> newY = dlY.transform(builder ->  builder.options(dlY.getOptions().transform(b-> b.setInstrumentation(instrA))));
+        DataLoader<String, String> newZ = dlZ.transform(builder ->  builder.options(dlZ.getOptions().transform(b-> b.setInstrumentation(instrA))));
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
                 .instrumentation(instrA)
                 .register("X", newX)

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
@@ -120,9 +120,9 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void wontDoAnyThingIfThereTheyAreTheSameInstrumentationAlready() {
-        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newY = dlX.transform(builder ->  builder.options(dlY.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newZ = dlX.transform(builder ->  builder.options(dlZ.getOptions().setInstrumentation(instrA)));
+        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().withInstrumentation(instrA)));
+        DataLoader<String, String> newY = dlX.transform(builder ->  builder.options(dlY.getOptions().withInstrumentation(instrA)));
+        DataLoader<String, String> newZ = dlX.transform(builder ->  builder.options(dlZ.getOptions().withInstrumentation(instrA)));
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
                 .instrumentation(instrA)
                 .register("X", newX)
@@ -145,7 +145,7 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void ifTheDLHasAInstrumentationThenItsTurnedIntoAChainedOne() {
-        DataLoaderOptions options = dlX.getOptions().setInstrumentation(instrA);
+        DataLoaderOptions options = dlX.getOptions().withInstrumentation(instrA);
         DataLoader<String, String> newX = dlX.transform(builder -> builder.options(options));
 
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
@@ -164,7 +164,7 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void chainedInstrumentationsWillBeCombined() {
-        DataLoaderOptions options = dlX.getOptions().setInstrumentation(chainedInstrB);
+        DataLoaderOptions options = dlX.getOptions().withInstrumentation(chainedInstrB);
         DataLoader<String, String> newX = dlX.transform(builder -> builder.options(options));
 
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
@@ -120,9 +120,9 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void wontDoAnyThingIfThereTheyAreTheSameInstrumentationAlready() {
-        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().withInstrumentation(instrA)));
-        DataLoader<String, String> newY = dlX.transform(builder ->  builder.options(dlY.getOptions().withInstrumentation(instrA)));
-        DataLoader<String, String> newZ = dlX.transform(builder ->  builder.options(dlZ.getOptions().withInstrumentation(instrA)));
+        DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().transform(b -> b.setInstrumentation(instrA))));
+        DataLoader<String, String> newY = dlX.transform(builder -> builder.options(dlY.getOptions().transform(b -> b.setInstrumentation(instrA))));
+        DataLoader<String, String> newZ = dlX.transform(builder -> builder.options(dlZ.getOptions().transform(b -> b.setInstrumentation(instrA))));
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
                 .instrumentation(instrA)
                 .register("X", newX)
@@ -145,7 +145,7 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void ifTheDLHasAInstrumentationThenItsTurnedIntoAChainedOne() {
-        DataLoaderOptions options = dlX.getOptions().withInstrumentation(instrA);
+        DataLoaderOptions options = dlX.getOptions().transform(b -> b.setInstrumentation(instrA));
         DataLoader<String, String> newX = dlX.transform(builder -> builder.options(options));
 
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
@@ -164,7 +164,7 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @Test
     void chainedInstrumentationsWillBeCombined() {
-        DataLoaderOptions options = dlX.getOptions().withInstrumentation(chainedInstrB);
+        DataLoaderOptions options = dlX.getOptions().transform(b -> b.setInstrumentation(chainedInstrB));
         DataLoader<String, String> newX = dlX.transform(builder -> builder.options(options));
 
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()

--- a/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
+++ b/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
@@ -83,7 +83,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 
@@ -92,7 +92,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_context() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValuesWithContext(), options);
 
@@ -101,7 +101,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_mapped_batch_load() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
 
         DataLoader<Integer, Integer> identityLoader = newMappedDataLoader(keysAsMapOfValues(), options);
 
@@ -110,7 +110,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_mapped_batch_load_with_context() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
 
         DataLoader<Integer, Integer> identityLoader = newMappedDataLoader(keysAsMapOfValuesWithContext(), options);
 
@@ -119,7 +119,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_an_async_scheduler() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(delayedScheduling(50));
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(delayedScheduling(50));
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 
@@ -160,7 +160,7 @@ public class BatchLoaderSchedulerTest {
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(funkyScheduler);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(funkyScheduler);
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 

--- a/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
+++ b/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
@@ -83,7 +83,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling).build();
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 
@@ -92,7 +92,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_context() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling).build();
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValuesWithContext(), options);
 
@@ -101,7 +101,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_mapped_batch_load() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling).build();
 
         DataLoader<Integer, Integer> identityLoader = newMappedDataLoader(keysAsMapOfValues(), options);
 
@@ -110,7 +110,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_a_simple_scheduler_with_mapped_batch_load_with_context() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(immediateScheduling);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(immediateScheduling).build();
 
         DataLoader<Integer, Integer> identityLoader = newMappedDataLoader(keysAsMapOfValuesWithContext(), options);
 
@@ -119,7 +119,7 @@ public class BatchLoaderSchedulerTest {
 
     @Test
     public void can_allow_an_async_scheduler() {
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(delayedScheduling(50));
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(delayedScheduling(50)).build();
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 
@@ -160,7 +160,7 @@ public class BatchLoaderSchedulerTest {
                 });
             }
         };
-        DataLoaderOptions options = DataLoaderOptions.newOptions().withBatchLoaderScheduler(funkyScheduler);
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(funkyScheduler).build();
 
         DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
 


### PR DESCRIPTION
https://github.com/graphql-java/java-dataloader/issues/190

We changed the semantics of DataLoaderOption to be immutable but we didnt change the API signature and this led to confusion and the possibility of bugs where previously mutable calls not longer took effect

See the issue from more details

This now makes this a breaking change and will fail at compile time