### PR TITLE
Breaking change - adds a name to a DataLoader 

### DIFF
--- a/src/main/java/org/dataloader/DataLoader.java
+++ b/src/main/java/org/dataloader/DataLoader.java
@@ -492,4 +492,11 @@ public class DataLoader<K, V> {
         return valueCache;
     }
 
+    @Override
+    public String toString() {
+        return "DataLoader{" +
+                "name='" + name + '\'' +
+                ", stats=" + stats +
+                '}';
+    }
 }

--- a/src/main/java/org/dataloader/DataLoaderFactory.java
+++ b/src/main/java/org/dataloader/DataLoaderFactory.java
@@ -33,7 +33,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newDataLoader(@Nullable String name, BatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -69,7 +83,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(@Nullable String name, BatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -95,7 +126,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newDataLoader(@Nullable String name, BatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -131,7 +176,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newDataLoaderWithTry(BatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(@Nullable String name, BatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -157,7 +219,20 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoader<K, V> batchLoadFunction, @Nullable DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newMappedDataLoader(@Nullable String name, MappedBatchLoader<K, V> batchLoadFunction, @Nullable DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -194,7 +269,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(@Nullable String name, MappedBatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -220,7 +312,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoader(MappedBatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newMappedDataLoader(@Nullable String name, MappedBatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -256,7 +362,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(@Nullable String name, MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -282,7 +405,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newPublisherDataLoader(@Nullable String name, BatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -318,7 +455,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(@Nullable String name, BatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -344,7 +498,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoader(BatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newPublisherDataLoader(@Nullable String name, BatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -380,7 +548,24 @@ public class DataLoaderFactory {
      * @see #newPublisherDataLoaderWithTry(BatchPublisher)
      */
     public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(BatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newPublisherDataLoaderWithTry(BatchPublisher)
+     */
+    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(@Nullable String name, BatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -406,7 +591,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(@Nullable String name, MappedBatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -442,7 +641,24 @@ public class DataLoaderFactory {
      * @see #newDataLoaderWithTry(BatchLoader)
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newDataLoaderWithTry(BatchLoader)
+     */
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(@Nullable String name, MappedBatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -468,7 +684,21 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(MappedBatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function with the provided options
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(@Nullable String name, MappedBatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
     }
 
     /**
@@ -504,11 +734,28 @@ public class DataLoaderFactory {
      * @see #newMappedPublisherDataLoaderWithTry(MappedBatchPublisher)
      */
     public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(batchLoadFunction, options);
+        return mkDataLoader(null, batchLoadFunction, options);
     }
 
-    static <K, V> DataLoader<K, V> mkDataLoader(Object batchLoadFunction, DataLoaderOptions options) {
-        return new DataLoader<>(batchLoadFunction, options);
+    /**
+     * Creates new DataLoader with the specified batch loader function and with the provided options
+     * where the batch loader function returns a list of
+     * {@link org.dataloader.Try} objects.
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use that uses {@link org.dataloader.Try} objects
+     * @param options           the options to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     * @see #newMappedPublisherDataLoaderWithTry(MappedBatchPublisher)
+     */
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(@Nullable String name, MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(name, batchLoadFunction, options);
+    }
+
+    static <K, V> DataLoader<K, V> mkDataLoader(@Nullable String name, Object batchLoadFunction, DataLoaderOptions options) {
+        return new DataLoader<>(name, batchLoadFunction, options);
     }
 
     /**
@@ -541,6 +788,7 @@ public class DataLoaderFactory {
      * @param <V> the value type
      */
     public static class Builder<K, V> {
+        String name;
         Object batchLoadFunction;
         DataLoaderOptions options = DataLoaderOptions.newOptions();
 
@@ -548,12 +796,13 @@ public class DataLoaderFactory {
         }
 
         Builder(DataLoader<?, ?> dataLoader) {
+            this.name = dataLoader.getName();
             this.batchLoadFunction = dataLoader.getBatchLoadFunction();
             this.options = dataLoader.getOptions();
         }
 
-        public Builder<K, V> batchLoadFunction(Object batchLoadFunction) {
-            this.batchLoadFunction = batchLoadFunction;
+        public Builder<K, V> name(String name) {
+            this.name = name;
             return this;
         }
 
@@ -562,8 +811,53 @@ public class DataLoaderFactory {
             return this;
         }
 
+        public Builder<K, V> batchLoadFunction(Object batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> batchLoader(BatchLoader<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> batchLoader(BatchLoaderWithContext<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> mappedBatchLoader(MappedBatchLoader<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> mappedBatchLoader(MappedBatchLoaderWithContext<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> publisherBatchLoader(BatchPublisher<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> publisherBatchLoader(BatchPublisherWithContext<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> mappedPublisherBatchLoader(MappedBatchPublisher<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
+        public Builder<K, V> mappedPublisherBatchLoader(MappedBatchPublisherWithContext<K, V> batchLoadFunction) {
+            this.batchLoadFunction = batchLoadFunction;
+            return this;
+        }
+
         public DataLoader<K, V> build() {
-            return mkDataLoader(batchLoadFunction, options);
+            return mkDataLoader(name, batchLoadFunction, options);
         }
     }
 }

--- a/src/main/java/org/dataloader/DataLoaderFactory.java
+++ b/src/main/java/org/dataloader/DataLoaderFactory.java
@@ -3,6 +3,8 @@ package org.dataloader;
 import org.dataloader.annotations.PublicApi;
 import org.jspecify.annotations.Nullable;
 
+import static org.dataloader.impl.Assertions.nonNull;
+
 /**
  * A factory class to create {@link DataLoader}s
  */
@@ -21,6 +23,20 @@ public class DataLoaderFactory {
      */
     public static <K, V> DataLoader<K, V> newDataLoader(BatchLoader<K, V> batchLoadFunction) {
         return newDataLoader(batchLoadFunction, null);
+    }
+
+    /**
+     * Creates new DataLoader with the specified batch loader function and default options
+     * (batching, caching and unlimited batch size).
+     *
+     * @param name              the name to use
+     * @param batchLoadFunction the batch load function to use
+     * @param <K>               the key type
+     * @param <V>               the value type
+     * @return a new DataLoader
+     */
+    public static <K, V> DataLoader<K, V> newDataLoader(String name, BatchLoader<K, V> batchLoadFunction) {
+        return newDataLoader(name, batchLoadFunction, null);
     }
 
     /**
@@ -46,8 +62,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newDataLoader(@Nullable String name, BatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newDataLoader(String name, BatchLoader<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -99,8 +115,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(@Nullable String name, BatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(String name, BatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -139,8 +155,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newDataLoader(@Nullable String name, BatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newDataLoader(String name, BatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -192,8 +208,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(@Nullable String name, BatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newDataLoaderWithTry(String name, BatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -231,8 +247,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newMappedDataLoader(@Nullable String name, MappedBatchLoader<K, V> batchLoadFunction, @Nullable DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedDataLoader(String name, MappedBatchLoader<K, V> batchLoadFunction, @Nullable DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -285,8 +301,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(@Nullable String name, MappedBatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(String name, MappedBatchLoader<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -325,8 +341,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newMappedDataLoader(@Nullable String name, MappedBatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedDataLoader(String name, MappedBatchLoaderWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -378,8 +394,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(@Nullable String name, MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedDataLoaderWithTry(String name, MappedBatchLoaderWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -418,8 +434,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newPublisherDataLoader(@Nullable String name, BatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newPublisherDataLoader(String name, BatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -471,8 +487,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(@Nullable String name, BatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(String name, BatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -511,8 +527,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newPublisherDataLoader(@Nullable String name, BatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newPublisherDataLoader(String name, BatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -564,8 +580,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newPublisherDataLoaderWithTry(BatchPublisher)
      */
-    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(@Nullable String name, BatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newPublisherDataLoaderWithTry(String name, BatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -604,8 +620,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(@Nullable String name, MappedBatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(String name, MappedBatchPublisher<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -657,8 +673,8 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newDataLoaderWithTry(BatchLoader)
      */
-    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(@Nullable String name, MappedBatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(String name, MappedBatchPublisher<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -697,8 +713,8 @@ public class DataLoaderFactory {
      * @param <V>               the value type
      * @return a new DataLoader
      */
-    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(@Nullable String name, MappedBatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoader(String name, MappedBatchPublisherWithContext<K, V> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
     /**
@@ -750,11 +766,11 @@ public class DataLoaderFactory {
      * @return a new DataLoader
      * @see #newMappedPublisherDataLoaderWithTry(MappedBatchPublisher)
      */
-    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(@Nullable String name, MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
-        return mkDataLoader(name, batchLoadFunction, options);
+    public static <K, V> DataLoader<K, V> newMappedPublisherDataLoaderWithTry(String name, MappedBatchPublisherWithContext<K, Try<V>> batchLoadFunction, DataLoaderOptions options) {
+        return mkDataLoader(nonNull(name), batchLoadFunction, options);
     }
 
-    static <K, V> DataLoader<K, V> mkDataLoader(@Nullable String name, Object batchLoadFunction, DataLoaderOptions options) {
+    static <K, V> DataLoader<K, V> mkDataLoader(@Nullable String name, Object batchLoadFunction, @Nullable DataLoaderOptions options) {
         return new DataLoader<>(name, batchLoadFunction, options);
     }
 

--- a/src/main/java/org/dataloader/DataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/DataLoaderRegistry.java
@@ -130,7 +130,29 @@ public class DataLoaderRegistry {
     }
 
     /**
-     * This will register a new dataloader
+     * This will register a new named dataloader.  The {@link DataLoader} must be named something and
+     * cannot have a null name.
+     * <p>
+     * Note: Registration can change the data loader instance since it might get an {@link DataLoaderInstrumentation} applied to
+     * it.  So the {@link DataLoader} instance your read via {@link DataLoaderRegistry#getDataLoader(String)} might not be the same
+     * object that was registered.
+     *
+     * @param dataLoader the named data loader to register
+     * @return this registry
+     */
+    public DataLoaderRegistry register(DataLoader<?, ?> dataLoader) {
+        String name = dataLoader.getName();
+        assertState(name != null, () -> "The DataLoader must have a non null name");
+        dataLoaders.put(name, nameAndInstrumentDL(name, instrumentation, dataLoader));
+        return this;
+    }
+
+    /**
+     * This will register a new {@link DataLoader}
+     * <p>
+     * Note: Registration can change the data loader instance since it might get an {@link DataLoaderInstrumentation} applied to
+     * it.  So the {@link DataLoader} instance your read via {@link DataLoaderRegistry#getDataLoader(String)} might not be the same
+     * object that was registered.
      *
      * @param key        the key to put the data loader under
      * @param dataLoader the data loader to register
@@ -142,8 +164,11 @@ public class DataLoaderRegistry {
     }
 
     /**
-     * This will register a new dataloader and then return it.  It might have been wrapped into a new instance
-     * because of the registry instrumentation for example.
+     * This will register a new {@link DataLoader} and then return it.
+     * <p>
+     * Note: Registration can change the data loader instance since it might get an {@link DataLoaderInstrumentation} applied to
+     * it.  So the {@link DataLoader} instance your read via {@link DataLoaderRegistry#getDataLoader(String)} might not be the same
+     * object that was registered.
      *
      * @param key        the key to put the data loader under
      * @param dataLoader the data loader to register
@@ -160,6 +185,10 @@ public class DataLoaderRegistry {
      * <p>
      * Note: The entire method invocation is performed atomically,
      * so the function is applied at most once per key.
+     * <p>
+     * Note: Registration can change the data loader instance since it might get an {@link DataLoaderInstrumentation} applied to
+     * it.  So the {@link DataLoader} instance your read via {@link DataLoaderRegistry#getDataLoader(String)} might not be the same
+     * object that was registered.
      *
      * @param key             the key of the data loader
      * @param mappingFunction the function to compute a data loader

--- a/src/main/java/org/dataloader/DelegatingDataLoader.java
+++ b/src/main/java/org/dataloader/DelegatingDataLoader.java
@@ -29,8 +29,8 @@ import java.util.function.Consumer;
  *       CompletableFuture<String> cf = super.load(key, keyContext);
  *       return cf.thenApply(v -> "|" + v + "|");
  *    }
- *};
- *}</pre>
+ * };
+ * }</pre>
  *
  * @param <K> type parameter indicating the type of the data load keys
  * @param <V> type parameter indicating the type of the data that is returned
@@ -58,7 +58,7 @@ public class DelegatingDataLoader<K, V> extends DataLoader<K, V> {
     }
 
     public DelegatingDataLoader(DataLoader<K, V> delegate) {
-        super(delegate.getBatchLoadFunction(), delegate.getOptions());
+        super(delegate.getName(), delegate.getBatchLoadFunction(), delegate.getOptions());
         this.delegate = delegate;
     }
 

--- a/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/registries/ScheduledDataLoaderRegistry.java
@@ -3,7 +3,10 @@ package org.dataloader.registries;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
 import org.dataloader.annotations.ExperimentalApi;
+import org.dataloader.impl.Assertions;
 import org.dataloader.instrumentation.DataLoaderInstrumentation;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -54,6 +57,7 @@ import static org.dataloader.impl.Assertions.nonNull;
  * This code is currently marked as {@link ExperimentalApi}
  */
 @ExperimentalApi
+@NullMarked
 public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements AutoCloseable {
 
     private final Map<DataLoader<?, ?>, DispatchPredicate> dataLoaderPredicates = new ConcurrentHashMap<>();
@@ -66,7 +70,7 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
 
     private ScheduledDataLoaderRegistry(Builder builder) {
         super(builder.dataLoaders, builder.instrumentation);
-        this.scheduledExecutorService = builder.scheduledExecutorService;
+        this.scheduledExecutorService = Assertions.nonNull(builder.scheduledExecutorService);
         this.defaultExecutorUsed = builder.defaultExecutorUsed;
         this.schedule = builder.schedule;
         this.tickerMode = builder.tickerMode;
@@ -112,7 +116,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      * and return a new combined registry
      *
      * @param registry the registry to combine into this registry
-     *
      * @return a new combined registry
      */
     public ScheduledDataLoaderRegistry combine(DataLoaderRegistry registry) {
@@ -128,7 +131,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      * This will unregister a new dataloader
      *
      * @param key the key of the data loader to unregister
-     *
      * @return this registry
      */
     public ScheduledDataLoaderRegistry unregister(String key) {
@@ -161,7 +163,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      * @param key               the key to put the data loader under
      * @param dataLoader        the data loader to register
      * @param dispatchPredicate the dispatch predicate to associate with this data loader
-     *
      * @return this registry
      */
     public ScheduledDataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
@@ -222,7 +223,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
      *
      * @param dataLoaderKey the key in the dataloader map
      * @param dataLoader    the dataloader
-     *
      * @return true if it should dispatch
      */
     private boolean shouldDispatch(String dataLoaderKey, DataLoader<?, ?> dataLoader) {
@@ -267,11 +267,11 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
         private final Map<String, DataLoader<?, ?>> dataLoaders = new LinkedHashMap<>();
         private final Map<DataLoader<?, ?>, DispatchPredicate> dataLoaderPredicates = new LinkedHashMap<>();
         private DispatchPredicate dispatchPredicate = DispatchPredicate.DISPATCH_ALWAYS;
-        private ScheduledExecutorService scheduledExecutorService;
+        private @Nullable ScheduledExecutorService scheduledExecutorService;
         private boolean defaultExecutorUsed = false;
         private Duration schedule = Duration.ofMillis(10);
         private boolean tickerMode = false;
-        private DataLoaderInstrumentation instrumentation;
+        private @Nullable DataLoaderInstrumentation instrumentation;
 
 
         /**
@@ -279,7 +279,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          * {@link ScheduledDataLoaderRegistry#close()} is called.  This is left to the code that made this setup code
          *
          * @param executorService the executor service to run the ticker on
-         *
          * @return this builder for a fluent pattern
          */
         public Builder scheduledExecutorService(ScheduledExecutorService executorService) {
@@ -297,7 +296,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          *
          * @param key        the key to put the data loader under
          * @param dataLoader the data loader to register
-         *
          * @return this builder for a fluent pattern
          */
         public Builder register(String key, DataLoader<?, ?> dataLoader) {
@@ -312,7 +310,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          * @param key               the key to put the data loader under
          * @param dataLoader        the data loader to register
          * @param dispatchPredicate the dispatch predicate
-         *
          * @return this builder for a fluent pattern
          */
         public Builder register(String key, DataLoader<?, ?> dataLoader, DispatchPredicate dispatchPredicate) {
@@ -326,7 +323,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          * from a previous {@link DataLoaderRegistry}
          *
          * @param otherRegistry the previous {@link DataLoaderRegistry}
-         *
          * @return this builder for a fluent pattern
          */
         public Builder registerAll(DataLoaderRegistry otherRegistry) {
@@ -343,7 +339,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          * whether all {@link DataLoader}s in the {@link DataLoaderRegistry }should be dispatched.
          *
          * @param dispatchPredicate the predicate
-         *
          * @return this builder for a fluent pattern
          */
         public Builder dispatchPredicate(DispatchPredicate dispatchPredicate) {
@@ -357,7 +352,6 @@ public class ScheduledDataLoaderRegistry extends DataLoaderRegistry implements A
          * to dispatchAll.
          *
          * @param tickerMode true or false
-         *
          * @return this builder for a fluent pattern
          */
         public Builder tickerMode(boolean tickerMode) {

--- a/src/test/java/org/dataloader/ClockDataLoader.java
+++ b/src/test/java/org/dataloader/ClockDataLoader.java
@@ -9,7 +9,7 @@ public class ClockDataLoader<K, V> extends DataLoader<K, V> {
     }
 
     public ClockDataLoader(Object batchLoadFunction, DataLoaderOptions options, Clock clock) {
-        super(batchLoadFunction, options, clock);
+        super(null, batchLoadFunction, options, clock);
     }
 
 }

--- a/src/test/java/org/dataloader/DataLoaderFactoryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderFactoryTest.java
@@ -1,0 +1,51 @@
+package org.dataloader;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DataLoaderFactoryTest {
+
+    @Test
+    void can_create_via_builder() {
+        BatchLoaderWithContext<String, String> loader = (keys, environment) -> CompletableFuture.completedFuture(keys);
+        DataLoaderOptions options = DataLoaderOptions.newOptionsBuilder().setBatchingEnabled(true).build();
+
+        DataLoader<String, String> dl = DataLoaderFactory.<String, String>builder()
+                .name("x").batchLoader(loader).options(options).build();
+
+        assertNotNull(dl.getName());
+        assertThat(dl.getName(), equalTo("x"));
+        assertThat(dl.getBatchLoadFunction(), equalTo(loader));
+        assertThat(dl.getOptions(), equalTo(options));
+
+        BatchLoaderWithContext<String, Try<String>> loaderTry = (keys, environment)
+                -> CompletableFuture.completedFuture(keys.stream().map(Try::succeeded).collect(Collectors.toList()));
+
+        DataLoader<String, Try<String>> dlTry = DataLoaderFactory.<String, Try<String>>builder()
+                .name("try").batchLoader(loaderTry).options(options).build();
+
+        assertNotNull(dlTry.getName());
+        assertThat(dlTry.getName(), equalTo("try"));
+        assertThat(dlTry.getBatchLoadFunction(), equalTo(loaderTry));
+        assertThat(dlTry.getOptions(), equalTo(options));
+
+        MappedBatchLoader<String, Try<String>> mappedLoaderTry = (keys)
+                -> CompletableFuture.completedFuture(
+                keys.stream().collect(Collectors.toMap(k -> k, Try::succeeded))
+        );
+
+        DataLoader<String, Try<String>> dlTry2 = DataLoaderFactory.<String, Try<String>>builder()
+                .name("try2").mappedBatchLoader(mappedLoaderTry).options(options).build();
+
+        assertNotNull(dlTry2.getName());
+        assertThat(dlTry2.getName(), equalTo("try2"));
+        assertThat(dlTry2.getBatchLoadFunction(), equalTo(mappedLoaderTry));
+        assertThat(dlTry2.getOptions(), equalTo(options));
+    }
+}

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -1,9 +1,12 @@
 package org.dataloader;
 
+import org.dataloader.impl.DataLoaderAssertionException;
 import org.dataloader.stats.SimpleStatisticsCollector;
 import org.dataloader.stats.Statistics;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Arrays.asList;
@@ -21,6 +24,7 @@ public class DataLoaderRegistryTest {
         DataLoader<Object, Object> dlA = newDataLoader("a", identityBatchLoader);
         DataLoader<Object, Object> dlB = newDataLoader("b", identityBatchLoader);
         DataLoader<Object, Object> dlC = newDataLoader("c", identityBatchLoader);
+        DataLoader<Object, Object> dlUnnamed = newDataLoader(identityBatchLoader);
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
@@ -40,7 +44,7 @@ public class DataLoaderRegistryTest {
 
         // and unregister (fluently)
         DataLoaderRegistry dlR = registry.unregister("c");
-        assertThat(dlR,equalTo(registry));
+        assertThat(dlR, equalTo(registry));
 
         assertThat(registry.getDataLoaders(), equalTo(asList(dlA, dlB)));
 
@@ -49,12 +53,24 @@ public class DataLoaderRegistryTest {
         assertThat(readDL, sameInstance(dlA));
 
         assertThat(registry.getKeys(), hasItems("a", "b"));
+
+
+        // named registry
+        registry = new DataLoaderRegistry();
+        registry.register(dlA);
+        assertThat(registry.getDataLoaders(), equalTo(List.of(dlA)));
+
+        try {
+            registry.register(dlUnnamed);
+            Assertions.fail("Should have thrown an exception");
+        } catch (DataLoaderAssertionException ignored) {
+        }
     }
 
     @Test
     public void registries_can_be_combined() {
 
-        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a", identityBatchLoader);
         DataLoader<Object, Object> dlB = newDataLoader("b", identityBatchLoader);
         DataLoader<Object, Object> dlC = newDataLoader("c", identityBatchLoader);
         DataLoader<Object, Object> dlD = newDataLoader("d", identityBatchLoader);
@@ -120,7 +136,7 @@ public class DataLoaderRegistryTest {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
-        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a", identityBatchLoader);
         DataLoader<Object, Object> registered = registry.computeIfAbsent("a", (key) -> dlA);
 
         assertThat(registered, equalTo(dlA));
@@ -133,7 +149,7 @@ public class DataLoaderRegistryTest {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
-        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a", identityBatchLoader);
         registry.computeIfAbsent("a", (key) -> dlA);
 
         // register again at same key

--- a/src/test/java/org/dataloader/DataLoaderRegistryTest.java
+++ b/src/test/java/org/dataloader/DataLoaderRegistryTest.java
@@ -18,9 +18,9 @@ public class DataLoaderRegistryTest {
 
     @Test
     public void registration_works() {
-        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a", identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader("b", identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader("c", identityBatchLoader);
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
@@ -54,10 +54,10 @@ public class DataLoaderRegistryTest {
     @Test
     public void registries_can_be_combined() {
 
-        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlC = newDataLoader(identityBatchLoader);
-        DataLoader<Object, Object> dlD = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
+        DataLoader<Object, Object> dlB = newDataLoader("b", identityBatchLoader);
+        DataLoader<Object, Object> dlC = newDataLoader("c", identityBatchLoader);
+        DataLoader<Object, Object> dlD = newDataLoader("d", identityBatchLoader);
 
         DataLoaderRegistry registry1 = new DataLoaderRegistry();
 
@@ -90,6 +90,10 @@ public class DataLoaderRegistryTest {
 
         registry.register("a", dlA).register("b", dlB).register("c", dlC);
 
+        dlA = registry.getDataLoader("a");
+        dlB = registry.getDataLoader("b");
+        dlC = registry.getDataLoader("b");
+
         dlA.load("X");
         dlB.load("Y");
         dlC.load("Z");
@@ -116,7 +120,7 @@ public class DataLoaderRegistryTest {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
-        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
         DataLoader<Object, Object> registered = registry.computeIfAbsent("a", (key) -> dlA);
 
         assertThat(registered, equalTo(dlA));
@@ -129,11 +133,11 @@ public class DataLoaderRegistryTest {
 
         DataLoaderRegistry registry = new DataLoaderRegistry();
 
-        DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA = newDataLoader("a",identityBatchLoader);
         registry.computeIfAbsent("a", (key) -> dlA);
 
         // register again at same key
-        DataLoader<Object, Object> dlA2 = newDataLoader(identityBatchLoader);
+        DataLoader<Object, Object> dlA2 = newDataLoader("a", identityBatchLoader);
         DataLoader<Object, Object> registered = registry.computeIfAbsent("a", (key) -> dlA2);
 
         assertThat(registered, equalTo(dlA));
@@ -149,8 +153,8 @@ public class DataLoaderRegistryTest {
         DataLoader<Object, Object> dlA = newDataLoader(identityBatchLoader);
         DataLoader<Object, Object> dlB = newDataLoader(identityBatchLoader);
 
-        registry.register("a", dlA);
-        registry.register("b", dlB);
+        dlA = registry.registerAndGet("a", dlA);
+        dlB = registry.registerAndGet("b", dlB);
 
         dlA.load("av1");
         dlA.load("av2");

--- a/src/test/java/org/dataloader/DataLoaderTest.java
+++ b/src/test/java/org/dataloader/DataLoaderTest.java
@@ -33,7 +33,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -43,8 +49,12 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
-import static java.util.concurrent.CompletableFuture.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.awaitility.Awaitility.await;
 import static org.dataloader.DataLoaderFactory.newDataLoader;
 import static org.dataloader.DataLoaderOptions.newOptions;
@@ -52,8 +62,13 @@ import static org.dataloader.fixtures.TestKit.areAllDone;
 import static org.dataloader.fixtures.TestKit.listFrom;
 import static org.dataloader.impl.CompletableFutureKit.cause;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for {@link DataLoader}.
@@ -80,6 +95,20 @@ public class DataLoaderTest {
         });
         identityLoader.dispatch();
         await().untilAtomic(success, is(true));
+    }
+
+    @Test
+    public void should_Build_a_named_data_loader() {
+        BatchLoader<Integer, Integer> loadFunction = CompletableFuture::completedFuture;
+        DataLoader<Integer, Integer> dl = newDataLoader("name", loadFunction, DataLoaderOptions.newOptions());
+
+        assertNotNull(dl.getName());
+        assertThat(dl.getName(), equalTo("name"));
+
+        DataLoader<Integer, Integer> dl2 = DataLoaderFactory.<Integer, Integer>builder().name("name2").batchLoader(loadFunction).build();
+
+        assertNotNull(dl2.getName());
+        assertThat(dl2.getName(), equalTo("name2"));
     }
 
     @Test

--- a/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
+++ b/src/test/java/org/dataloader/DelegatingDataLoaderTest.java
@@ -4,6 +4,7 @@ import org.dataloader.fixtures.TestKit;
 import org.dataloader.fixtures.parameterized.DelegatingDataLoaderFactory;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * There are WAY more tests via the {@link DelegatingDataLoaderFactory}
@@ -60,5 +62,19 @@ public class DelegatingDataLoaderTest {
 
         assertThat(delegatingDataLoader.getIfCompleted("A").isEmpty(), equalTo(false));
         assertThat(delegatingDataLoader.getIfCompleted("X").isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void can_delegate_simple_properties() {
+        DataLoaderOptions options = DataLoaderOptions.newOptions();
+        BatchLoader<String, String> loadFunction = CompletableFuture::completedFuture;
+
+        DataLoader<String, String> rawLoader = DataLoaderFactory.newDataLoader("name", loadFunction, options);
+        DelegatingDataLoader<String, String> delegate = new DelegatingDataLoader<>(rawLoader);
+
+        assertNotNull(delegate.getName());
+        assertThat(delegate.getName(),equalTo("name"));
+        assertThat(delegate.getOptions(),equalTo(options));
+        assertThat(delegate.getBatchLoadFunction(),equalTo(loadFunction));
     }
 }

--- a/src/test/java/org/dataloader/fixtures/TestKit.java
+++ b/src/test/java/org/dataloader/fixtures/TestKit.java
@@ -11,8 +11,8 @@ import org.dataloader.MappedBatchLoaderWithContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,8 +64,16 @@ public class TestKit {
         return idLoader(null, new ArrayList<>());
     }
 
+    public static <K, V> DataLoader<K, V> idLoader(String name) {
+        return idLoader(name, null, new ArrayList<>());
+    }
+
     public static <K, V> DataLoader<K, V> idLoader(DataLoaderOptions options, List<List<K>> loadCalls) {
         return DataLoaderFactory.newDataLoader(keysAsValues(loadCalls), options);
+    }
+
+    public static <K, V> DataLoader<K, V> idLoader(String name, DataLoaderOptions options, List<List<K>> loadCalls) {
+        return DataLoaderFactory.newDataLoader(name, keysAsValues(loadCalls), options);
     }
 
     public static Collection<Integer> listFrom(int i, int max) {
@@ -104,7 +112,7 @@ public class TestKit {
 
     public static boolean areAllDone(CompletableFuture<?>... cfs) {
         for (CompletableFuture<?> cf : cfs) {
-            if (! cf.isDone()) {
+            if (!cf.isDone()) {
                 return false;
             }
         }

--- a/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
+++ b/src/test/java/org/dataloader/instrumentation/DataLoaderRegistryInstrumentationTest.java
@@ -32,9 +32,9 @@ public class DataLoaderRegistryInstrumentationTest {
 
     @BeforeEach
     void setUp() {
-        dlX = TestKit.idLoader();
-        dlY = TestKit.idLoader();
-        dlZ = TestKit.idLoader();
+        dlX = TestKit.idLoader("X");
+        dlY = TestKit.idLoader("Y");
+        dlZ = TestKit.idLoader("Z");
         instrA = new CapturingInstrumentation("A");
         instrB = new CapturingInstrumentation("B");
         chainedInstrA = new ChainedDataLoaderInstrumentation().add(instrA);
@@ -121,8 +121,8 @@ public class DataLoaderRegistryInstrumentationTest {
     @Test
     void wontDoAnyThingIfThereTheyAreTheSameInstrumentationAlready() {
         DataLoader<String, String> newX = dlX.transform(builder -> builder.options(dlX.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newY = dlX.transform(builder ->  builder.options(dlY.getOptions().setInstrumentation(instrA)));
-        DataLoader<String, String> newZ = dlX.transform(builder ->  builder.options(dlZ.getOptions().setInstrumentation(instrA)));
+        DataLoader<String, String> newY = dlY.transform(builder ->  builder.options(dlY.getOptions().setInstrumentation(instrA)));
+        DataLoader<String, String> newZ = dlZ.transform(builder ->  builder.options(dlZ.getOptions().setInstrumentation(instrA)));
         DataLoaderRegistry registry = DataLoaderRegistry.newRegistry()
                 .instrumentation(instrA)
                 .register("X", newX)


### PR DESCRIPTION
This adds name to a DataLoader which we should have done from the start in retrospect

This helps Instrumentation so they can report stats in terms of "names".