### PR TITLE
OSGI - Make org.jspecify.* imports optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ jar {
                 '-exportcontents': 'org.dataloader.*',
                 '-removeheaders': 'Private-Package')
     }
+    bnd('''
+Import-Package: org.jspecify.annotations;resolution:=optional,*
+''')
 }
 
 dependencies {


### PR DESCRIPTION
Since org.specify import is not necessarily needed at runtime, can we make it optional?