### PR TITLE
Make generic value types nullable

### DIFF
--- a/src/main/java/org/dataloader/BatchLoader.java
+++ b/src/main/java/org/dataloader/BatchLoader.java
@@ -19,6 +19,7 @@ package org.dataloader;
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -77,7 +78,7 @@ import java.util.concurrent.CompletionStage;
 @FunctionalInterface
 @PublicSpi
 @NullMarked
-public interface BatchLoader<K, V> {
+public interface BatchLoader<K, V extends @Nullable Object> {
 
     /**
      * Called to batch load the provided keys and return a promise to a list of values.

--- a/src/main/java/org/dataloader/BatchLoaderWithContext.java
+++ b/src/main/java/org/dataloader/BatchLoaderWithContext.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -16,7 +17,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface BatchLoaderWithContext<K, V> {
+public interface BatchLoaderWithContext<K, V extends @Nullable Object> {
     /**
      * Called to batch load the provided keys and return a promise to a list of values.  This default
      * version can be given an environment object to that maybe be useful during the call.  A typical use case

--- a/src/main/java/org/dataloader/BatchPublisher.java
+++ b/src/main/java/org/dataloader/BatchPublisher.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 @NullMarked
 @PublicSpi
-public interface BatchPublisher<K, V> {
+public interface BatchPublisher<K, V extends @Nullable Object> {
     /**
      * Called to batch the provided keys into a stream of values.  You <b>must</b> provide
      * the same number of values as there as keys, and they <b>must</b> be in the order of the keys.

--- a/src/main/java/org/dataloader/BatchPublisherWithContext.java
+++ b/src/main/java/org/dataloader/BatchPublisherWithContext.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.List;
  */
 @NullMarked
 @PublicSpi
-public interface BatchPublisherWithContext<K, V> {
+public interface BatchPublisherWithContext<K, V extends @Nullable Object> {
     /**
      * Called to batch the provided keys into a stream of values.  You <b>must</b> provide
      * the same number of values as there as keys, and they <b>must</b> be in the order of the keys.

--- a/src/main/java/org/dataloader/MappedBatchLoader.java
+++ b/src/main/java/org/dataloader/MappedBatchLoader.java
@@ -18,6 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +60,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchLoader<K, V> {
+public interface MappedBatchLoader<K, V extends @Nullable Object> {
 
     /**
      * Called to batch load the provided keys and return a promise to a map of values.

--- a/src/main/java/org/dataloader/MappedBatchLoaderWithContext.java
+++ b/src/main/java/org/dataloader/MappedBatchLoaderWithContext.java
@@ -18,6 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -33,7 +34,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchLoaderWithContext<K, V> {
+public interface MappedBatchLoaderWithContext<K, V extends @Nullable Object> {
     /**
      * Called to batch load the provided keys and return a promise to a map of values.
      *

--- a/src/main/java/org/dataloader/MappedBatchPublisher.java
+++ b/src/main/java/org/dataloader/MappedBatchPublisher.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import java.util.Map;
@@ -20,7 +21,7 @@ import java.util.Set;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchPublisher<K, V> {
+public interface MappedBatchPublisher<K, V extends @Nullable Object> {
     /**
      * Called to batch the provided keys into a stream of map entries of keys and values.
      * <p>

--- a/src/main/java/org/dataloader/MappedBatchPublisherWithContext.java
+++ b/src/main/java/org/dataloader/MappedBatchPublisherWithContext.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.Map;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchPublisherWithContext<K, V> {
+public interface MappedBatchPublisherWithContext<K, V extends @Nullable Object> {
 
     /**
      * Called to batch the provided keys into a stream of map entries of keys and values.


### PR DESCRIPTION
Based on this issue: https://github.com/graphql-java/java-dataloader/issues/195

The fix was implemented for the `DataLoader` class, but we should apply it also to the other interfaces to not break Kotlin clients.