### PR TITLE
More explicit nullable annotations on BatchLoader interfaces

### DIFF
--- a/src/main/java/org/dataloader/BatchLoader.java
+++ b/src/main/java/org/dataloader/BatchLoader.java
@@ -17,8 +17,8 @@
 package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -40,7 +40,7 @@ import java.util.concurrent.CompletionStage;
  *      2, 9, 6, 1
  *  ]
  * </pre>
- *
+ * <p>
  * and loading from a back-end service returned this list of  values:
  *
  * <pre>
@@ -50,7 +50,7 @@ import java.util.concurrent.CompletionStage;
  *      { id: 2, name: 'San Francisco' },
  *  ]
  * </pre>
- *
+ * <p>
  * then the batch loader function contract has been broken.
  * <p>
  * The back-end service returned results in a different order than we requested, likely because it was more efficient for it to
@@ -77,7 +77,7 @@ import java.util.concurrent.CompletionStage;
 @FunctionalInterface
 @PublicSpi
 @NullMarked
-public interface BatchLoader<K, V> {
+public interface BatchLoader<K, V extends @Nullable Object> {
 
     /**
      * Called to batch load the provided keys and return a promise to a list of values.
@@ -85,7 +85,6 @@ public interface BatchLoader<K, V> {
      * If you need calling context then implement {@link org.dataloader.BatchLoaderWithContext}
      *
      * @param keys the collection of keys to load
-     *
      * @return a promise of the values for those keys
      */
     CompletionStage<List<V>> load(List<K> keys);

--- a/src/main/java/org/dataloader/BatchLoaderWithContext.java
+++ b/src/main/java/org/dataloader/BatchLoaderWithContext.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -16,7 +17,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface BatchLoaderWithContext<K, V> {
+public interface BatchLoaderWithContext<K, V extends @Nullable Object> {
     /**
      * Called to batch load the provided keys and return a promise to a list of values.  This default
      * version can be given an environment object to that maybe be useful during the call.  A typical use case

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -594,11 +594,11 @@ class DataLoaderHelper<K, V> {
     }
 
     private boolean isPublisher() {
-        return batchLoadFunction instanceof BatchPublisher;
+        return batchLoadFunction instanceof BatchPublisher || batchLoadFunction instanceof BatchPublisherWithContext;
     }
 
     private boolean isMappedPublisher() {
-        return batchLoadFunction instanceof MappedBatchPublisher;
+        return batchLoadFunction instanceof MappedBatchPublisher || batchLoadFunction instanceof MappedBatchPublisherWithContext;
     }
 
     private DataLoaderInstrumentation instrumentation() {

--- a/src/main/java/org/dataloader/MappedBatchLoader.java
+++ b/src/main/java/org/dataloader/MappedBatchLoader.java
@@ -18,6 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +60,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchLoader<K, V> {
+public interface MappedBatchLoader<K, V extends @Nullable Object> {
 
     /**
      * Called to batch load the provided keys and return a promise to a map of values.

--- a/src/main/java/org/dataloader/MappedBatchLoaderWithContext.java
+++ b/src/main/java/org/dataloader/MappedBatchLoaderWithContext.java
@@ -18,6 +18,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Set;
@@ -33,7 +34,7 @@ import java.util.concurrent.CompletionStage;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchLoaderWithContext<K, V> {
+public interface MappedBatchLoaderWithContext<K, V extends @Nullable Object> {
     /**
      * Called to batch load the provided keys and return a promise to a map of values.
      *

--- a/src/main/java/org/dataloader/MappedBatchPublisher.java
+++ b/src/main/java/org/dataloader/MappedBatchPublisher.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import java.util.Map;
@@ -20,7 +21,7 @@ import java.util.Set;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchPublisher<K, V> {
+public interface MappedBatchPublisher<K, V extends @Nullable Object> {
     /**
      * Called to batch the provided keys into a stream of map entries of keys and values.
      * <p>

--- a/src/main/java/org/dataloader/MappedBatchPublisherWithContext.java
+++ b/src/main/java/org/dataloader/MappedBatchPublisherWithContext.java
@@ -2,6 +2,7 @@ package org.dataloader;
 
 import org.dataloader.annotations.PublicSpi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Subscriber;
 
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.Map;
  */
 @PublicSpi
 @NullMarked
-public interface MappedBatchPublisherWithContext<K, V> {
+public interface MappedBatchPublisherWithContext<K, V extends @Nullable Object> {
 
     /**
      * Called to batch the provided keys into a stream of map entries of keys and values.


### PR DESCRIPTION
This adds `V extends @Nullable Object` on the batch loader interfaces to indicate that the values can be null.