### PR TITLE
Allow value nullability for ValueCache

### DIFF
--- a/src/main/java/org/dataloader/ValueCache.java
+++ b/src/main/java/org/dataloader/ValueCache.java
@@ -3,6 +3,7 @@ package org.dataloader;
 import org.dataloader.annotations.PublicSpi;
 import org.dataloader.impl.CompletableFutureKit;
 import org.dataloader.impl.NoOpValueCache;
+import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @PublicSpi
 @NullMarked
-public interface ValueCache<K, V> {
+public interface ValueCache<K, V extends @Nullable Object> {
 
     /**
      * Creates a new value cache, using the default no-op implementation.

--- a/src/test/kotlin/org/dataloader/KotlinExamples.kt
+++ b/src/test/kotlin/org/dataloader/KotlinExamples.kt
@@ -1,8 +1,10 @@
 package org.dataloader
 
+import java.util.concurrent.CompletableFuture
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import java.util.concurrent.CompletableFuture.completedFuture
+import org.dataloader.impl.NoOpValueCache
 
 /**
  * Some Kotlin code to prove that are JSpecify annotations work here
@@ -79,6 +81,19 @@ class KotlinExamples {
         val dataLoader: DataLoader<String, String?> = DataLoaderFactory.newMappedPublisherDataLoader(batchLoadFunction)
 
         standardNullableAsserts(dataLoader)
+    }
+
+    @Test
+    fun `basic kotlin test of nullable value types in value cache`() {
+        val valueCache = object : ValueCache<String, String?> by NoOpValueCache() {
+            override fun get(key: String): CompletableFuture<String?> = if (key == "null")
+                completedFuture(null)
+            else
+                completedFuture(key)
+        }
+
+        assert(valueCache["key"].get() == "key")
+        assert(valueCache["null"].get() == null)
     }
 
     private fun standardNullableAsserts(dataLoader: DataLoader<String, String?>) {


### PR DESCRIPTION
Related to https://github.com/graphql-java/java-dataloader/pull/207.

Since values form DataLoader are nullable, we might also want to have null values cached.

@bbakerman