### PR TITLE
Kotlin stdlib should not be a pom dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.41.0'
 
     // just tests
-    testCompileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 tasks.withType(JavaCompile) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,6 @@ awaitility_version=2.0.0
 reactor_core_version=3.6.6
 caffeine_version=3.1.8
 reactive_streams_version=1.0.3
-``
 # Prevents the Kotlin stdlib being a POM dependency
 #
 # https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,8 @@ awaitility_version=2.0.0
 reactor_core_version=3.6.6
 caffeine_version=3.1.8
 reactive_streams_version=1.0.3
+``
+# Prevents the Kotlin stdlib being a POM dependency
+#
+# https://kotlinlang.org/docs/gradle-configure-project.html#dependency-on-the-standard-library
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
See #227

Local maven publish says

```
<dependencies>
    <dependency>
      <groupId>org.reactivestreams</groupId>
      <artifactId>reactive-streams</artifactId>
      <version>1.0.3</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.jspecify</groupId>
      <artifactId>jspecify</artifactId>
      <version>1.0.0</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
  <name>java-dataloader</name>
  <description>A pure Java 11 port of Facebook Dataloader</description>
  <url>https://github.com/graphql-java/java-dataloader</url>
  <inceptionYear>2017</inceptionYear>
```