### PR TITLE
Add strict mode for DataLoaderRegistry

### DIFF
--- a/src/main/java/org/dataloader/DataLoaderRegistry.java
+++ b/src/main/java/org/dataloader/DataLoaderRegistry.java
@@ -85,7 +85,10 @@ public class DataLoaderRegistry {
      * @param existingDL              the existing data loader
      * @return a new {@link DataLoader} or the same one if there is nothing to change
      */
-    private static DataLoader<?, ?> nameAndInstrumentDL(String key, @Nullable DataLoaderInstrumentation registryInstrumentation, DataLoader<?, ?> existingDL) {
+    private DataLoader<?, ?> nameAndInstrumentDL(String key, @Nullable DataLoaderInstrumentation registryInstrumentation, DataLoader<?, ?> existingDL) {
+        if (strictMode) {
+            assertKeyStrictly(key);
+        }
         existingDL = checkAndSetName(key, existingDL);
 
         if (registryInstrumentation == null) {
@@ -153,9 +156,6 @@ public class DataLoaderRegistry {
      */
     public DataLoaderRegistry register(DataLoader<?, ?> dataLoader) {
         String name = Assertions.nonNull(dataLoader.getName(), () -> "The DataLoader must have a non null name");
-        if (strictMode) {
-            assertKeyStrictly(name);
-        }
         dataLoaders.put(name, nameAndInstrumentDL(name, instrumentation, dataLoader));
         return this;
     }
@@ -172,9 +172,6 @@ public class DataLoaderRegistry {
      * @return this registry
      */
     public DataLoaderRegistry register(String key, DataLoader<?, ?> dataLoader) {
-        if (strictMode) {
-            assertKeyStrictly(key);
-        }
         dataLoaders.put(key, nameAndInstrumentDL(key, instrumentation, dataLoader));
         return this;
     }
@@ -191,9 +188,6 @@ public class DataLoaderRegistry {
      * @return the data loader instance that was registered
      */
     public <K, V> DataLoader<K, V> registerAndGet(String key, DataLoader<?, ?> dataLoader) {
-        if (strictMode) {
-            assertKeyStrictly(key);
-        }
         dataLoaders.put(key, nameAndInstrumentDL(key, instrumentation, dataLoader));
         return Objects.requireNonNull(getDataLoader(key));
     }

--- a/src/main/java/org/dataloader/errors/StrictModeRegistryException.java
+++ b/src/main/java/org/dataloader/errors/StrictModeRegistryException.java
@@ -1,0 +1,14 @@
+package org.dataloader.errors;
+
+import org.dataloader.annotations.PublicApi;
+
+/**
+ * An exception that is thrown when {@link org.dataloader.DataLoaderRegistry.Builder#strictMode(boolean)} is true and multiple
+ * DataLoaders are registered to the same key.
+ */
+@PublicApi
+public class StrictModeRegistryException extends RuntimeException {
+    public StrictModeRegistryException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
In a similar vein to https://github.com/graphql-java/graphql-java/pull/3565 which enabled "strict mode" for type wiring (preventing multiple `DataFetcher`s being registered to the same field on a GraphQL type), we add "strict mode" to the `DataLoaderRegistry` so that we don't accidentally register multiple DataLoaders to the same key (which would result in the last registration winning). This can prevent confusing bugs from emerging.

This defaults to `false` to avoid breaking changes, and deliberately mimics the referenced PR to maintain consistency.