### PR TITLE
Allow scheduling of CF completion - Attempt 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ This is an example of running the completion step in an asynchronous manner :
 ```java
 
 @Override
-public <K> CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+public <K> CompletionStage<Void> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
     return CompletableFuture.runAsync(completeValuesRunnable);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -633,6 +633,40 @@ Do not assume that a single call to `dispatch()` results in a single call to `Ba
 
 This code is inspired from the scheduling code in the [reference JS implementation](https://github.com/graphql/dataloader#batch-scheduling)
 
+### Scheduling DataLoader promise completion
+
+Another step in the batch loading process is the completion of the futures that have been promised earlier via
+`Dataloader.load()`. This can also be scheduled on another thread if need be, allowing the dispatch call 
+to return quicker.
+
+You might want to schedule the completion of values on another thread if there is following work t do such as :
+
+```java
+var cfStage1 = dataLoader.load(key);
+var cfStage2 = cfStage1.thenApply(v -> doSomethingSlow(v));
+//...
+var dispatchCF = dataLoader.dispatch();
+```     
+
+In the above example the `.doSomethingSlow(v)` call will happen inside the completion
+of the `cfStage1` code path since `CompletableFuture` by design eagerly runs dependent chained methods.
+
+Perhaps you want this completion to happen more asynchronously so that the `.dispatch()` returns more
+quickly and is not bound to the `.doSomethingSlow(v)` call.
+
+By default, the dispatch completion is done on the current thread in a synchronous manner, which will include
+any extra `CompletableFuture` chained methods.
+
+This is an example of running the completion step in an asynchronous manner :
+
+```java
+
+@Override
+public <K> CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+    return CompletableFuture.runAsync(completeValuesRunnable);
+}
+```
+
 ## Scheduled Registry Dispatching
 
 `ScheduledDataLoaderRegistry` is a registry that allows for dispatching to be done on a schedule. It contains a

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -242,7 +242,7 @@ class DataLoaderHelper<K, V> {
         int queueSize = loaderQueueEntryHead.queueSize;
         // we copy the pre-loaded set of futures ready for dispatch
         Object[] keysArray = new Object[queueSize];
-        CompletableFuture[] queuedFuturesArray = new CompletableFuture[queueSize];
+        CompletableFuture<V>[] queuedFuturesArray = new CompletableFuture[queueSize];
         Object[] callContextsArray = new Object[queueSize];
         int index = queueSize - 1;
         while (loaderQueueEntryHead != null) {

--- a/src/main/java/org/dataloader/DataLoaderHelper.java
+++ b/src/main/java/org/dataloader/DataLoaderHelper.java
@@ -19,7 +19,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
 import static org.dataloader.impl.Assertions.assertState;
@@ -313,54 +311,56 @@ class DataLoaderHelper<K, V> {
         }
         //
         // now reassemble all the futures into one that is the complete set of results
-        return allOf(allBatches.toArray(new CompletableFuture[0]))
-                .thenApply(v -> allBatches.stream()
-                        .map(CompletableFuture::join)
-                        .flatMap(Collection::stream)
-                        .collect(toList()));
+        return CompletableFutureKit.allOfFlatMap(allBatches);
     }
 
     @SuppressWarnings("unchecked")
-    private CompletableFuture<List<V>> dispatchQueueBatch(List<K> keys, List<Object> callContexts, List<CompletableFuture<V>> queuedFutures) {
-        stats.incrementBatchLoadCountBy(keys.size(), new IncrementBatchLoadCountByStatisticsContext<>(keys, callContexts));
-        CompletableFuture<List<V>> batchLoad = invokeLoader(keys, callContexts, queuedFutures, loaderOptions.cachingEnabled());
+    private CompletableFuture<List<V>> dispatchQueueBatch(List<K> keys, List<Object> keyContexts, List<CompletableFuture<V>> queuedFutures) {
+        stats.incrementBatchLoadCountBy(keys.size(), new IncrementBatchLoadCountByStatisticsContext<>(keys, keyContexts));
+
+        BatchLoaderEnvironment environment = mkBatchLoaderEnv(keys, keyContexts);
+
+        CompletableFuture<List<V>> batchLoad = invokeLoader(environment, keys, keyContexts, queuedFutures, loaderOptions.cachingEnabled());
         return batchLoad
-                .thenApply(values -> {
+                .thenCompose(values -> {
                     assertResultSize(keys, values);
                     if (isPublisher() || isMappedPublisher()) {
                         // We have already completed the queued futures by the time the overall batchLoad future has completed.
-                        return values;
+                        return CompletableFutureKit.success(values);
                     }
 
-                    List<K> clearCacheKeys = new ArrayList<>();
-                    for (int idx = 0; idx < queuedFutures.size(); idx++) {
-                        K key = keys.get(idx);
-                        V value = values.get(idx);
-                        Object callContext = callContexts.get(idx);
-                        CompletableFuture<V> future = queuedFutures.get(idx);
-                        if (value instanceof Throwable) {
-                            stats.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(key, callContext));
-                            future.completeExceptionally((Throwable) value);
-                            clearCacheKeys.add(keys.get(idx));
-                        } else if (value instanceof Try) {
-                            // we allow the batch loader to return a Try so we can better represent a computation
-                            // that might have worked or not.
-                            Try<V> tryValue = (Try<V>) value;
-                            if (tryValue.isSuccess()) {
-                                future.complete(tryValue.get());
-                            } else {
+                    Runnable completeValuesRunnable = () -> {
+                        List<K> clearCacheKeys = new ArrayList<>();
+                        for (int idx = 0; idx < queuedFutures.size(); idx++) {
+                            K key = keys.get(idx);
+                            V value = values.get(idx);
+                            Object callContext = keyContexts.get(idx);
+                            CompletableFuture<V> future = queuedFutures.get(idx);
+                            if (value instanceof Throwable) {
                                 stats.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(key, callContext));
-                                future.completeExceptionally(tryValue.getThrowable());
+                                future.completeExceptionally((Throwable) value);
                                 clearCacheKeys.add(keys.get(idx));
+                            } else if (value instanceof Try) {
+                                // we allow the batch loader to return a Try so we can better represent a computation
+                                // that might have worked or not.
+                                Try<V> tryValue = (Try<V>) value;
+                                if (tryValue.isSuccess()) {
+                                    future.complete(tryValue.get());
+                                } else {
+                                    stats.incrementLoadErrorCount(new IncrementLoadErrorCountStatisticsContext<>(key, callContext));
+                                    future.completeExceptionally(tryValue.getThrowable());
+                                    clearCacheKeys.add(keys.get(idx));
+                                }
+                            } else {
+                                future.complete(value);
                             }
-                        } else {
-                            future.complete(value);
                         }
-                    }
-                    possiblyClearCacheEntriesOnExceptions(clearCacheKeys);
-                    return values;
+                        possiblyClearCacheEntriesOnExceptions(clearCacheKeys);
+                    };
+
+                    return scheduleCompletion(environment, keys, values, completeValuesRunnable);
                 }).exceptionally(ex -> {
-                    stats.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(keys, callContexts));
+                    stats.incrementBatchLoadExceptionCount(new IncrementBatchLoadExceptionCountStatisticsContext<>(keys, keyContexts));
                     if (ex instanceof CompletionException) {
                         ex = ex.getCause();
                     }
@@ -373,6 +373,26 @@ class DataLoaderHelper<K, V> {
                     }
                     return emptyList();
                 });
+    }
+
+    private CompletableFuture<List<V>> scheduleCompletion(BatchLoaderEnvironment environment, List<K> keys, List<V> values, Runnable completeValuesRunnable) {
+        BatchLoaderScheduler batchLoaderScheduler = loaderOptions.getBatchLoaderScheduler();
+        CompletionStage<?> scheduledCompletion;
+        if (batchLoaderScheduler != null) {
+            scheduledCompletion = batchLoaderScheduler
+                    .scheduleCompletion(completeValuesRunnable, keys, environment);
+        } else {
+            scheduledCompletion = CompletableFutureKit.run(completeValuesRunnable);
+        }
+        return scheduledCompletion
+                .thenApply(ignored -> values)
+                .toCompletableFuture();
+    }
+
+    private BatchLoaderEnvironment mkBatchLoaderEnv(List<K> keys, List<Object> keyContexts) {
+        Object context = loaderOptions.getBatchLoaderContextProvider().getContext();
+        return BatchLoaderEnvironment.newBatchLoaderEnvironment()
+                .context(context).keyContexts(keys, keyContexts).build();
     }
 
 
@@ -396,15 +416,17 @@ class DataLoaderHelper<K, V> {
     CompletableFuture<V> invokeLoaderImmediately(K key, Object keyContext, boolean cachingEnabled) {
         List<K> keys = singletonList(key);
         List<Object> keyContexts = singletonList(keyContext);
+        BatchLoaderEnvironment environment = mkBatchLoaderEnv(keys, keyContexts);
+
         List<CompletableFuture<V>> queuedFutures = singletonList(new CompletableFuture<>());
-        return invokeLoader(keys, keyContexts, queuedFutures, cachingEnabled)
+        return invokeLoader(environment, keys, keyContexts, queuedFutures, cachingEnabled)
                 .thenApply(list -> list.get(0))
                 .toCompletableFuture();
     }
 
-    CompletableFuture<List<V>> invokeLoader(List<K> keys, List<Object> keyContexts, List<CompletableFuture<V>> queuedFutures, boolean cachingEnabled) {
+    CompletableFuture<List<V>> invokeLoader(BatchLoaderEnvironment environment, List<K> keys, List<Object> keyContexts, List<CompletableFuture<V>> queuedFutures, boolean cachingEnabled) {
         if (!cachingEnabled) {
-            return invokeLoader(keys, keyContexts, queuedFutures);
+            return invokeLoader(environment, keys, keyContexts, queuedFutures);
         }
         CompletableFuture<List<Try<V>>> cacheCallCF = getFromValueCache(keys);
         return cacheCallCF.thenCompose(cachedValues -> {
@@ -453,7 +475,7 @@ class DataLoaderHelper<K, V> {
                 // we missed some keys from cache, so send them to the batch loader
                 // and then fill in their values
                 //
-                CompletableFuture<List<V>> batchLoad = invokeLoader(missedKeys, missedKeyContexts, missedQueuedFutures);
+                CompletableFuture<List<V>> batchLoad = invokeLoader(environment, missedKeys, missedKeyContexts, missedQueuedFutures);
                 return batchLoad.thenCompose(missedValues -> {
                     assertResultSize(missedKeys, missedValues);
 
@@ -472,11 +494,7 @@ class DataLoaderHelper<K, V> {
         });
     }
 
-    CompletableFuture<List<V>> invokeLoader(List<K> keys, List<Object> keyContexts, List<CompletableFuture<V>> queuedFutures) {
-        Object context = loaderOptions.getBatchLoaderContextProvider().getContext();
-        BatchLoaderEnvironment environment = BatchLoaderEnvironment.newBatchLoaderEnvironment()
-                .context(context).keyContexts(keys, keyContexts).build();
-
+    CompletableFuture<List<V>> invokeLoader(BatchLoaderEnvironment environment, List<K> keys, List<Object> keyContexts, List<CompletableFuture<V>> queuedFutures) {
         DataLoaderInstrumentationContext<List<?>> instrCtx = ctxOrNoopCtx(instrumentation().beginBatchLoader(dataLoader, keys, environment));
 
         CompletableFuture<List<V>> batchLoad;

--- a/src/main/java/org/dataloader/impl/CompletableFutureKit.java
+++ b/src/main/java/org/dataloader/impl/CompletableFutureKit.java
@@ -84,7 +84,7 @@ public class CompletableFutureKit {
                         .collect(toList()));
     }
 
-    public static CompletableFuture<?> run(Runnable runnable) {
+    public static CompletableFuture<Void> run(Runnable runnable) {
         try {
             runnable.run();
             return CompletableFutureKit.success(null);

--- a/src/main/java/org/dataloader/impl/CompletableFutureKit.java
+++ b/src/main/java/org/dataloader/impl/CompletableFutureKit.java
@@ -2,6 +2,7 @@ package org.dataloader.impl;
 
 import org.dataloader.annotations.Internal;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -19,6 +20,12 @@ public class CompletableFutureKit {
     public static <V> CompletableFuture<V> failedFuture(Exception e) {
         CompletableFuture<V> future = new CompletableFuture<>();
         future.completeExceptionally(e);
+        return future;
+    }
+
+    public static <V> CompletableFuture<V> success(V v) {
+        CompletableFuture<V> future = new CompletableFuture<>();
+        future.complete(v);
         return future;
     }
 
@@ -66,5 +73,23 @@ public class CompletableFutureKit {
                                         task -> task.getValue().join())
                         )
                 );
+    }
+
+    public static <T> CompletableFuture<List<T>> allOfFlatMap(List<CompletableFuture<List<T>>> cfs) {
+
+        return CompletableFuture.allOf(cfs.toArray(new CompletableFuture[0]))
+                .thenApply(v -> cfs.stream()
+                        .map(CompletableFuture::join)
+                        .flatMap(Collection::stream)
+                        .collect(toList()));
+    }
+
+    public static CompletableFuture<?> run(Runnable runnable) {
+        try {
+            runnable.run();
+            return CompletableFutureKit.success(null);
+        } catch (Exception e) {
+            return CompletableFutureKit.failedFuture(e);
+        }
     }
 }

--- a/src/main/java/org/dataloader/scheduler/BatchLoaderScheduler.java
+++ b/src/main/java/org/dataloader/scheduler/BatchLoaderScheduler.java
@@ -128,7 +128,7 @@ public interface BatchLoaderScheduler {
      *
      * @return a {@link CompletionStage} representing this work is being scheduled
      */
-    default <K>  CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+    default <K>  CompletionStage<Void> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
         return CompletableFutureKit.run(completeValuesRunnable);
     }
 

--- a/src/main/java/org/dataloader/scheduler/BatchLoaderScheduler.java
+++ b/src/main/java/org/dataloader/scheduler/BatchLoaderScheduler.java
@@ -2,11 +2,12 @@ package org.dataloader.scheduler;
 
 import org.dataloader.BatchLoader;
 import org.dataloader.BatchLoaderEnvironment;
+import org.dataloader.BatchPublisher;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 import org.dataloader.MappedBatchLoader;
 import org.dataloader.MappedBatchPublisher;
-import org.dataloader.BatchPublisher;
+import org.dataloader.impl.CompletableFutureKit;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ public interface BatchLoaderScheduler {
      * @param <V> the value type
      */
     interface ScheduledBatchLoaderCall<V> {
+
         CompletionStage<List<V>> invoke();
     }
 
@@ -41,6 +43,7 @@ public interface BatchLoaderScheduler {
      * @param <V> the value type
      */
     interface ScheduledMappedBatchLoaderCall<K, V> {
+
         CompletionStage<Map<K, V>> invoke();
     }
 
@@ -48,6 +51,7 @@ public interface BatchLoaderScheduler {
      * This represents a callback that will invoke a {@link BatchPublisher} or {@link MappedBatchPublisher} function under the covers
      */
     interface ScheduledBatchPublisherCall {
+
         void invoke();
     }
 
@@ -92,4 +96,40 @@ public interface BatchLoaderScheduler {
      * @param <K>           the key type
      */
     <K> void scheduleBatchPublisher(ScheduledBatchPublisherCall scheduledCall, List<K> keys, BatchLoaderEnvironment environment);
+
+    /**
+     * This is called to schedule the "completion" of the {@link java.util.concurrent.CompletableFuture}s in the {@link org.dataloader.DataLoader} that map
+     * to values that have come back from the batch loader call.
+     * <p>
+     * You might want to schedule the completion of values on another thread if there following chained work such as :
+     * <pre>
+     * {@code
+     *   var cfStage1 = dataLoader.load(key);
+     *   var cfStage2 = cfStage1.thenApply(v -> doSomethingSlow(v));
+     *   //...
+     *   var dispatchCF = dataLoader.dispatch();
+     * }
+     * </pre>
+     * <p>
+     * In the above example the `.doSomethingSlow(v)` call will happen inside the completion
+     * of the dataloader code path when it tries to complete `cfStage1` since {@link java.util.concurrent.CompletableFuture}
+     * by design runs chained dependent methods eagerly.
+     * <p>
+     * Perhaps you want this tp happen more asynchronously so that the `.dispatch()` returns more
+     * quickly and is not bound to the `.doSomethingSlow(v)` call.
+     * <p>
+     * By default, the dispatch completion is done on the current thread in a synchronous manner, which will include
+     * any extra {@link java.util.concurrent.CompletableFuture} dependent chained methods.
+     *
+     * @param completeValuesRunnable this is the runnable that the {@link DataLoader} engine code needs to be run
+     * @param keys          this is the list of keys that will be passed to the {@link BatchPublisher}.
+     *                      This is provided only for informative reasons and, you can't change the keys that are used
+     * @param environment   this is the {@link BatchLoaderEnvironment} in place,
+     *
+     * @return a {@link CompletionStage} representing this work is being scheduled
+     */
+    default <K>  CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+        return CompletableFutureKit.run(completeValuesRunnable);
+    }
+
 }

--- a/src/test/java/org/dataloader/impl/CompletableFutureKitTest.java
+++ b/src/test/java/org/dataloader/impl/CompletableFutureKitTest.java
@@ -1,0 +1,102 @@
+package org.dataloader.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CompletableFutureKitTest {
+
+    @Test
+    void failedFuture() {
+        CompletableFuture<Object> cf = CompletableFutureKit.failedFuture(new RuntimeException("BANG"));
+        assertThat(cf.isCompletedExceptionally(), equalTo(true));
+        CompletionException completionException = assertThrows(CompletionException.class, cf::join);
+        assertThat(completionException.getCause().getMessage(), equalTo("BANG"));
+    }
+
+    @Test
+    void success() {
+        CompletableFuture<Object> cf = CompletableFutureKit.success("BANG");
+        assertThat(cf.isCompletedExceptionally(), equalTo(false));
+        assertThat(cf.join(), equalTo("BANG"));
+    }
+
+    @Test
+    void cause() {
+        CompletableFuture<Object> cf = CompletableFutureKit.failedFuture(new RuntimeException("BANG"));
+        assertThat(CompletableFutureKit.cause(cf), instanceOf(RuntimeException.class));
+    }
+
+    @Test
+    void succeeded() {
+        CompletableFuture<Object> cf = CompletableFutureKit.success("BANG");
+        assertThat(CompletableFutureKit.succeeded(cf), equalTo(true));
+        assertThat(CompletableFutureKit.failed(cf), equalTo(false));
+    }
+
+    @Test
+    void failed() {
+        CompletableFuture<Object> cf = CompletableFutureKit.failedFuture(new RuntimeException("BANG"));
+        assertThat(CompletableFutureKit.failed(cf), equalTo(true));
+        assertThat(CompletableFutureKit.succeeded(cf), equalTo(false));
+    }
+
+    @Test
+    void allOf() {
+        CompletableFuture<List<String>> list = CompletableFutureKit.allOf(List.of(
+                CompletableFutureKit.success("1"),
+                CompletableFutureKit.success("2"),
+                CompletableFutureKit.success("3")
+        ));
+
+        assertThat(list.join(), equalTo(List.of("1", "2", "3")));
+    }
+
+    @Test
+    void flatMapAllOf() {
+
+        CompletableFuture<List<String>> list1 = CompletableFutureKit.allOf(List.of(
+                CompletableFutureKit.success("1"),
+                CompletableFutureKit.success("2"),
+                CompletableFutureKit.success("3")
+        ));
+        CompletableFuture<List<String>> list2 = CompletableFutureKit.allOf(List.of(
+                CompletableFutureKit.success("4"),
+                CompletableFutureKit.success("5"),
+                CompletableFutureKit.success("6")
+        ));
+
+        CompletableFuture<List<String>> list = CompletableFutureKit.allOfFlatMap(List.of(list1, list2));
+        assertThat(list.join(), equalTo(List.of("1", "2", "3", "4", "5", "6")));
+
+    }
+
+    @Test
+    void run() {
+        AtomicBoolean ran = new AtomicBoolean(false);
+        Runnable runnable = () -> ran.set(true);
+
+        CompletableFuture<?> runCF = CompletableFutureKit.run(runnable);
+        runCF.join();
+        assertThat(ran.get(), equalTo(true));
+
+        runnable = () -> {
+            throw new RuntimeException("BANG");
+        };
+
+        runCF = CompletableFutureKit.run(runnable);
+
+        CompletionException completionException = assertThrows(CompletionException.class, runCF::join);
+        assertThat(completionException.getCause().getMessage(), equalTo("BANG"));
+
+
+    }
+}

--- a/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
+++ b/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
@@ -184,4 +184,75 @@ public class BatchLoaderSchedulerTest {
     }
 
 
+    @Test
+    void can_schedule_cf_completion() {
+
+        AtomicBoolean useThreading = new AtomicBoolean(false);
+        BatchLoaderScheduler scheduler = new BatchLoaderScheduler() {
+            @Override
+            public <K, V> CompletionStage<List<V>> scheduleBatchLoader(ScheduledBatchLoaderCall<V> scheduledCall, List<K> keys, BatchLoaderEnvironment environment) {
+                return scheduledCall.invoke();
+            }
+
+            @Override
+            public <K, V> CompletionStage<Map<K, V>> scheduleMappedBatchLoader(ScheduledMappedBatchLoaderCall<K, V> scheduledCall, List<K> keys, BatchLoaderEnvironment environment) {
+                return scheduledCall.invoke();
+            }
+
+            @Override
+            public <K> void scheduleBatchPublisher(ScheduledBatchPublisherCall scheduledCall, List<K> keys, BatchLoaderEnvironment environment) {
+                scheduledCall.invoke();
+            }
+
+            @Override
+            public <K> CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+                if (useThreading.get()) {
+                    snooze(500);
+                    return CompletableFuture.runAsync(completeValuesRunnable);
+                } else {
+                    return BatchLoaderScheduler.super.scheduleCompletion(completeValuesRunnable, keys, environment);
+                }
+            }
+        };
+
+        DataLoaderOptions options = DataLoaderOptions.newOptions().setBatchLoaderScheduler(scheduler).build();
+
+        DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
+
+        CompletableFuture<Integer> cf1 = identityLoader.load(1);
+        CompletableFuture<Integer> cf2 = identityLoader.load(2);
+        CompletableFuture<List<Integer>> dispatchCF = identityLoader.dispatch();
+
+        await().until(dispatchCF::isDone);
+        assertThat(cf1.join(), equalTo(1));
+        assertThat(cf2.join(), equalTo(2));
+
+        // switch mode to threading mdoe
+
+        useThreading.set(true);
+
+        cf1 = identityLoader.load(10);
+        cf2 = identityLoader.load(20);
+        dispatchCF = identityLoader.dispatch();
+
+
+        await().until(dispatchCF::isDone);
+        assertThat(cf1.join(), equalTo(10));
+        assertThat(cf2.join(), equalTo(20));
+    }
+
+    @Test
+    void no_scheduler_present_will_works() {
+        DataLoaderOptions options = DataLoaderOptions.newOptions().build();
+
+        DataLoader<Integer, Integer> identityLoader = newDataLoader(keysAsValues(), options);
+
+        CompletableFuture<Integer> cf1 = identityLoader.load(1);
+        CompletableFuture<Integer> cf2 = identityLoader.load(2);
+        CompletableFuture<List<Integer>> dispatchCF = identityLoader.dispatch();
+
+        await().until(dispatchCF::isDone);
+        assertThat(cf1.join(), equalTo(1));
+        assertThat(cf2.join(), equalTo(2));
+    }
 }

--- a/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
+++ b/src/test/java/org/dataloader/scheduler/BatchLoaderSchedulerTest.java
@@ -205,7 +205,7 @@ public class BatchLoaderSchedulerTest {
             }
 
             @Override
-            public <K> CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
+            public <K> CompletionStage<Void> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
                 if (useThreading.get()) {
                     snooze(500);
                     return CompletableFuture.runAsync(completeValuesRunnable);


### PR DESCRIPTION
The completion of CF promises can now be scheduled on another thread

A step in the batch loading process is the completion of the futures that have been promised earlier via
`Dataloader.load()`. This can also be scheduled on another thread if need be, allowing the dispatch call 
to return quicker.

You might want to schedule the completion of values on another thread if there is following work t do such as :

```java
var cfStage1 = dataLoader.load(key);
var cfStage2 = cfStage1.thenApply(v -> doSomethingSlow(v));
//...
var dispatchCF = dataLoader.dispatch();
```     

In the above example the `.doSomethingSlow(v)` call will happen inside the completion
of the `cfStage1` code path since `CompletableFuture` by design eagerly runs dependent chained methods.

Perhaps you want this completion to happen more asynchronously so that the `.dispatch()` returns more
quickly and is not bound to the `.doSomethingSlow(v)` call.

By default, the dispatch completion is done on the current thread in a synchronous manner, which will include
any extra `CompletableFuture` chained methods.

This is an example of running the completion step in an asynchronous manner :

```java

@Override
public <K> CompletionStage<?> scheduleCompletion(Runnable completeValuesRunnable, List<K> keys, BatchLoaderEnvironment environment) {
    return CompletableFuture.runAsync(completeValuesRunnable);
}
```